### PR TITLE
feat: side-by-side pinned-WebKit engine store (next alpha)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunmaska",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "description": "A drop-in replacement for Electron, built on Bun and system WebKit.",
   "keywords": [
     "electron",

--- a/src/cli/build-linux.ts
+++ b/src/cli/build-linux.ts
@@ -12,6 +12,7 @@
 
 import { chmodSync, copyFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { isSystemEngine, parseEngineId } from '../common/engine-id';
 import { BUNMASKA_VERSION } from '../common/version';
 import { bundleIdSlug } from './build-macos';
 
@@ -21,6 +22,8 @@ export type LinuxLayout = {
   readonly binPath: string;
   readonly desktopPath: string;
   readonly iconPath: string;
+  /** The baked engine-id, read at launch (resolves `usr/bin/<slug>` -> here). */
+  readonly engineIdPath: string;
 };
 
 /** Compute every on-disk path of an `<out>/<Name>` AppDir-style tree. Pure. */
@@ -33,7 +36,26 @@ export const linuxLayout = (out: string, name: string): LinuxLayout => {
     binPath: join(appDir, 'usr', 'bin', slug),
     desktopPath: join(appDir, 'usr', 'share', 'applications', `${slug}.desktop`),
     iconPath: join(appDir, 'usr', 'share', 'icons', 'hicolor', '512x512', 'apps', `${slug}.png`),
+    engineIdPath: join(appDir, 'usr', 'share', slug, 'engine.id'),
   };
+};
+
+/**
+ * The engine-id to bake from a project's `engine.webkit` pin: a full id verbatim,
+ * else the `system` sentinel. A bare upstream version (e.g. `2.52.4`) downgrades
+ * to `system` for now — resolving it to a full id needs the engine catalog (a
+ * follow-up); the caller should surface that.
+ */
+export const resolveBuildEngineId = (webkitPin: string | undefined): string => {
+  if (webkitPin === undefined || isSystemEngine(webkitPin)) {
+    return 'system';
+  }
+  try {
+    parseEngineId(webkitPin);
+    return webkitPin;
+  } catch {
+    return 'system';
+  }
 };
 
 /** File name of the `.tar.gz` distributable for an app. Pure. */
@@ -68,7 +90,17 @@ export type ControlFileOptions = {
   readonly version: string;
   readonly maintainer: string;
   readonly description: string;
+  /** Runtime package dependencies (`Depends:`). Omitted from the field when empty. */
+  readonly depends?: readonly string[];
 };
+
+/**
+ * Runtime packages a non-embedded Bunmaska `.deb` needs: the system WebKitGTK 6.0
+ * web view and its GTK 4 toolkit. Without this, an `apt install` on a minimal box
+ * leaves the app to crash at the first `dlopen` (the latent bug this fixes). Debian
+ * package names confirmed on sid: `libwebkitgtk-6.0-4`, `libgtk-4-1`.
+ */
+export const DEFAULT_LINUX_DEPENDS: readonly string[] = ['libwebkitgtk-6.0-4', 'libgtk-4-1'];
 
 /** Build the Debian `control` file text. Pure. */
 export const buildControlFile = (opts: ControlFileOptions): string =>
@@ -77,6 +109,9 @@ export const buildControlFile = (opts: ControlFileOptions): string =>
     `Version: ${opts.version}`,
     'Architecture: amd64',
     `Maintainer: ${opts.maintainer}`,
+    ...(opts.depends !== undefined && opts.depends.length > 0
+      ? [`Depends: ${opts.depends.join(', ')}`]
+      : []),
     `Description: ${opts.description}`,
     '',
   ].join('\n');
@@ -156,6 +191,10 @@ export type BuildLinuxAppOptions = {
   readonly id?: string;
   readonly out?: string;
   readonly icon?: string;
+  /** Engine-id to bake (the per-app pin); `system` (the default) = OS WebView. */
+  readonly engineId?: string;
+  /** Engine shipped inside the bundle — drops the system WebKitGTK `Depends:`. */
+  readonly embedEngine?: boolean;
 };
 
 export type BuildLinuxAppResult = {
@@ -193,10 +232,17 @@ export const buildLinuxApp = async (opts: BuildLinuxAppOptions): Promise<BuildLi
     copyFileSync(opts.icon, layout.iconPath);
   }
 
+  // Bake the engine-id the app pins, read at launch by the engine resolver.
+  mkdirSync(dirname(layout.engineIdPath), { recursive: true });
+  writeFileSync(layout.engineIdPath, `${opts.engineId ?? 'system'}\n`);
+
   // .tar.gz of the AppDir (use the system tar; -C keeps paths relative).
   const tarball = join(out, tarballName(opts.name));
   await spawnOk(['tar', '-czf', tarball, '-C', out, opts.name]);
 
+  // An embedded engine ships its own WebKitGTK; otherwise the app needs the
+  // system WebKitGTK + GTK (this Depends line is the fix for the latent crash).
+  const depends = opts.embedEngine === true ? [] : DEFAULT_LINUX_DEPENDS;
   const deb = await packageDeb({
     layout,
     out,
@@ -204,6 +250,7 @@ export const buildLinuxApp = async (opts: BuildLinuxAppOptions): Promise<BuildLi
     name: opts.name,
     maintainer,
     description,
+    depends,
   });
 
   return { appDir: layout.appDir, tarball, deb };
@@ -222,15 +269,16 @@ const packageDeb = async (args: {
   readonly name: string;
   readonly maintainer: string;
   readonly description: string;
+  readonly depends: readonly string[];
 }): Promise<string> => {
-  const { layout, out, version, name, maintainer, description } = args;
+  const { layout, out, version, name, maintainer, description, depends } = args;
   const staging = join(out, `.deb-${layout.slug}`);
   const controlDir = join(staging, 'control-root');
   mkdirSync(controlDir, { recursive: true });
 
   writeFileSync(
     join(controlDir, 'control'),
-    buildControlFile({ slug: layout.slug, version, maintainer, description }),
+    buildControlFile({ slug: layout.slug, version, maintainer, description, depends }),
   );
 
   const controlTar = join(staging, 'control.tar.gz');

--- a/src/cli/engine-command.ts
+++ b/src/cli/engine-command.ts
@@ -127,7 +127,23 @@ const runUse = (id: string, forDir: string | undefined, deps: EngineCommandDeps)
   return 0;
 };
 
-const runPrune = async (dryRun: boolean, deps: EngineCommandDeps): Promise<number> => {
+const runPrune = async (
+  dryRun: boolean,
+  force: boolean,
+  deps: EngineCommandDeps,
+): Promise<number> => {
+  // Refcounts are populated by apps at launch. Before any app has registered,
+  // every engine looks unreferenced — so a plain prune would wipe the whole
+  // store. Refuse that case unless explicitly forced (or just previewing).
+  const installed = listInstalled(deps.root);
+  if (!dryRun && !force && installed.length > 0 && readLinks(deps.root).length === 0) {
+    deps.out(
+      `Refusing to prune: no app has registered a dependency yet, so all ${installed.length} ` +
+        'installed engine(s) look unreferenced. Apps register on launch — re-run with --force ' +
+        'to prune anyway, or --dry-run to preview.',
+    );
+    return 0;
+  }
   const result = await gc(deps.root, { dryRun });
   if (result.removed.length === 0) {
     deps.out('Nothing to prune — every installed engine is still referenced.');
@@ -177,7 +193,7 @@ export const runEngine = async (
     case 'use':
       return runUse(sub.id, sub.for, deps);
     case 'prune':
-      return await runPrune(sub.dryRun, deps);
+      return await runPrune(sub.dryRun, sub.force, deps);
     case 'verify':
       return runVerify(sub.id, deps);
   }

--- a/src/cli/engine-command.ts
+++ b/src/cli/engine-command.ts
@@ -1,0 +1,229 @@
+/**
+ * The `bunmaska engine …` and `bunmaska doctor` command implementations.
+ *
+ * Kept out of the CLI entry (`index.ts`) and built on injected seams (store
+ * root, output sinks, a config reader) so every branch is unit-testable on any
+ * host without touching the real `~/.bunmaska` store or a project on disk.
+ */
+
+import { existsSync, statSync } from 'node:fs';
+import { compareEngineIds, isSystemEngine, parseEngineId } from '../common/engine-id';
+import type { BunmaskaConfig } from '../common/config-schema';
+import { currentArch, currentPlatform } from '../common/platform';
+import type { EngineSubcommand } from './parse-args';
+import {
+  gc,
+  type InstallResult,
+  installFromDir,
+  isInstalled,
+  listInstalled,
+  readLinks,
+  type StoreEnv,
+  verifyEngine,
+} from './engine-store';
+
+/** Injected dependencies for the engine/doctor commands. */
+export type EngineCommandDeps = {
+  /** The engine store root (the `webkit/` dir). */
+  readonly root: string;
+  readonly env: StoreEnv;
+  readonly out: (text: string) => void;
+  readonly err: (text: string) => void;
+  /** Read a project's validated config (empty `{}` when none). */
+  readonly readConfig: (target: string) => Promise<BunmaskaConfig>;
+  /** Install seam (default: {@link installFromDir}). */
+  readonly installDir?: (root: string, sourceDir: string) => Promise<InstallResult>;
+};
+
+/** Sort engine ids ascending, tolerating any non-id dir names. */
+const sortIds = (ids: readonly string[]): string[] =>
+  [...ids].sort((a, b) => {
+    try {
+      return compareEngineIds(a, b);
+    } catch {
+      return a < b ? -1 : a > b ? 1 : 0;
+    }
+  });
+
+/** The pinned engine declared by a project's config (defaults to the system sentinel). */
+const configPin = (config: BunmaskaConfig): string => config.engine?.webkit ?? 'system';
+
+const runList = (deps: EngineCommandDeps): number => {
+  const installed = listInstalled(deps.root);
+  if (installed.length === 0) {
+    deps.out('No engines installed — apps use the system WebKit by default.');
+    return 0;
+  }
+  const refs = new Map<string, number>();
+  for (const link of readLinks(deps.root)) {
+    refs.set(link.engine, (refs.get(link.engine) ?? 0) + 1);
+  }
+  for (const id of sortIds(installed)) {
+    const count = refs.get(id) ?? 0;
+    deps.out(`${id}  (${count} app${count === 1 ? '' : 's'})`);
+  }
+  return 0;
+};
+
+const runWhich = async (target: string | undefined, deps: EngineCommandDeps): Promise<number> => {
+  const config = await deps.readConfig(target ?? '.');
+  const pin = configPin(config);
+  if (isSystemEngine(pin)) {
+    deps.out('system — uses the OS WebView (no pinned engine)');
+    return 0;
+  }
+  try {
+    parseEngineId(pin);
+    const state = isInstalled(deps.root, pin)
+      ? 'installed'
+      : 'NOT installed — run `bunmaska engine install`';
+    deps.out(`${pin}  [${state}]`);
+  } catch {
+    deps.out(`${pin}  (bare upstream — resolved to a full engine-id at build time)`);
+  }
+  return 0;
+};
+
+const runInstall = async (source: string, deps: EngineCommandDeps): Promise<number> => {
+  if (existsSync(source) && statSync(source).isDirectory()) {
+    const install = deps.installDir ?? installFromDir;
+    const result = await install(deps.root, source);
+    deps.out(
+      result.installed
+        ? `installed ${result.id}`
+        : `${result.id} is already installed (nothing to do)`,
+    );
+    return 0;
+  }
+  deps.err(
+    `bunmaska engine install: ${JSON.stringify(source)} is not a local engine directory. ` +
+      'Hosted/remote engine installs are not available yet — pass a path to a built engine dir ' +
+      '(see .admin/ENGINE-STORE-PLAN.md). ',
+  );
+  return 1;
+};
+
+const runUse = (id: string, forDir: string | undefined, deps: EngineCommandDeps): number => {
+  if (!isSystemEngine(id)) {
+    try {
+      parseEngineId(id);
+    } catch (error) {
+      deps.err(`bunmaska engine use: ${error instanceof Error ? error.message : String(error)}`);
+      return 1;
+    }
+  }
+  const where = forDir ?? '.';
+  deps.out(
+    `Pin this engine per-project in ${where}/bunmaska.config.ts (there is no global switch):`,
+  );
+  deps.out('');
+  deps.out('  export default defineConfig({');
+  deps.out(`    engine: { webkit: ${JSON.stringify(id)} },`);
+  deps.out('  });');
+  deps.out('');
+  deps.out(
+    `Then \`bunmaska engine install ${id}\` (or build with an embedded engine) to fetch it.`,
+  );
+  return 0;
+};
+
+const runPrune = async (dryRun: boolean, deps: EngineCommandDeps): Promise<number> => {
+  const result = await gc(deps.root, { dryRun });
+  if (result.removed.length === 0) {
+    deps.out('Nothing to prune — every installed engine is still referenced.');
+  } else {
+    deps.out(
+      `${dryRun ? 'Would remove' : 'Removed'} ${result.removed.length} unreferenced engine(s):`,
+    );
+    for (const id of result.removed) {
+      deps.out(`  ${id}`);
+    }
+  }
+  if (result.droppedLinks > 0) {
+    deps.out(`Dropped ${result.droppedLinks} dead app link(s).`);
+  }
+  deps.out(`Kept ${result.kept.length} referenced engine(s).`);
+  if (dryRun) {
+    deps.out('(dry run — nothing was deleted)');
+  }
+  return 0;
+};
+
+const runVerify = (id: string, deps: EngineCommandDeps): number => {
+  const result = verifyEngine(deps.root, id);
+  if (result.ok) {
+    deps.out(`${id}: ok`);
+    return 0;
+  }
+  deps.err(`${id}: FAILED`);
+  for (const problem of result.problems) {
+    deps.err(`  - ${problem}`);
+  }
+  return 1;
+};
+
+/** Run a `bunmaska engine <sub>` command and resolve to the process exit code. */
+export const runEngine = async (
+  sub: EngineSubcommand,
+  deps: EngineCommandDeps,
+): Promise<number> => {
+  switch (sub.action) {
+    case 'list':
+      return runList(deps);
+    case 'which':
+      return await runWhich(sub.target, deps);
+    case 'install':
+      return await runInstall(sub.source, deps);
+    case 'use':
+      return runUse(sub.id, sub.for, deps);
+    case 'prune':
+      return await runPrune(sub.dryRun, deps);
+    case 'verify':
+      return runVerify(sub.id, deps);
+  }
+};
+
+/**
+ * `bunmaska doctor` — a Tauri-`info`-style health report: runtime, platform,
+ * the engine store, and the resolved pin for a project. Exits non-zero only when
+ * the project pins a full engine-id that is not installed (a real misconfig).
+ */
+export const runDoctor = async (
+  target: string | undefined,
+  deps: EngineCommandDeps,
+): Promise<number> => {
+  const installed = listInstalled(deps.root);
+  deps.out('Bunmaska doctor');
+  deps.out(`  bun:       ${Bun.version}`);
+  deps.out(`  platform:  ${currentPlatform()}-${currentArch()}`);
+  deps.out(`  store:     ${deps.root}`);
+  deps.out(`  engines:   ${installed.length} installed`);
+  deps.out(
+    currentPlatform() === 'macos'
+      ? '  webkit:    system WKWebView (pinning deferred on macOS)'
+      : '  webkit:    WebKitGTK 6.0 (system soname libwebkitgtk-6.0.so.4)',
+  );
+
+  const config = await deps.readConfig(target ?? '.');
+  const pin = configPin(config);
+  if (isSystemEngine(pin)) {
+    deps.out('  project:   system WebKit (no pin)');
+    return 0;
+  }
+  let isFullId = true;
+  try {
+    parseEngineId(pin);
+  } catch {
+    isFullId = false;
+  }
+  if (!isFullId) {
+    deps.out(`  project:   pins ${pin} (bare upstream, resolved at build time)`);
+    return 0;
+  }
+  if (isInstalled(deps.root, pin)) {
+    deps.out(`  project:   pins ${pin} [installed ✓]`);
+    return 0;
+  }
+  deps.err(`  project:   pins ${pin} [NOT installed ✗] — run \`bunmaska engine install ${pin}\``);
+  return 1;
+};

--- a/src/cli/engine-store.ts
+++ b/src/cli/engine-store.ts
@@ -19,6 +19,7 @@
 
 import {
   closeSync,
+  cpSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -175,6 +176,103 @@ export const installFromSource = async (
     rmSync(staging, { recursive: true, force: true });
     throw error;
   }
+};
+
+/** The `engine.json` manifest shipped inside every engine dir. */
+export type EngineManifest = {
+  readonly id: string;
+  readonly soname: string;
+  readonly hash?: string;
+  readonly size?: number;
+};
+
+/** Read + validate an engine's `engine.json` from a dir. Throws if missing/invalid. */
+export const readEngineManifest = (dir: string): EngineManifest => {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(join(dir, 'engine.json'), 'utf8'));
+  } catch {
+    throw new BunmaskaError(`engine: no readable engine.json in ${dir}`, {
+      code: 'ERR_ENGINE_MANIFEST',
+    });
+  }
+  const record = (raw ?? {}) as Record<string, unknown>;
+  if (typeof record['id'] !== 'string' || typeof record['soname'] !== 'string') {
+    throw new BunmaskaError(`engine: engine.json in ${dir} must have string "id" and "soname"`, {
+      code: 'ERR_ENGINE_MANIFEST',
+    });
+  }
+  return {
+    id: record['id'],
+    soname: record['soname'],
+    ...(typeof record['hash'] === 'string' ? { hash: record['hash'] } : {}),
+    ...(typeof record['size'] === 'number' ? { size: record['size'] } : {}),
+  };
+};
+
+/**
+ * Install an engine from a local, already-extracted engine DIRECTORY (a `lib/` +
+ * `engine.json` tree the developer built or fetched deliberately — the trusted
+ * local source for Phase 1; remote hash-verified installs are the follow-up).
+ * Copies the tree in atomically and writes the marker last. Idempotent.
+ */
+export const installFromDir = async (
+  root: string,
+  sourceDir: string,
+  deps: { readonly copyTree?: (from: string, to: string) => void } = {},
+): Promise<InstallResult> => {
+  const manifest = readEngineManifest(sourceDir);
+  if (isInstalled(root, manifest.id)) {
+    return { id: manifest.id, installed: false };
+  }
+  const copyTree = deps.copyTree ?? ((from, to) => cpSync(from, to, { recursive: true }));
+  mkdirSync(root, { recursive: true });
+  const staging = mkdtempSync(join(root, '.tmp-'));
+  try {
+    copyTree(sourceDir, staging);
+    const dest = engineDir(root, manifest.id);
+    rmSync(dest, { recursive: true, force: true });
+    renameSync(staging, dest);
+    writeFileSync(markerPath(root, manifest.id), `${new Date().toISOString()}\n`);
+    return { id: manifest.id, installed: true };
+  } catch (error) {
+    rmSync(staging, { recursive: true, force: true });
+    throw error;
+  }
+};
+
+/** The outcome of {@link verifyEngine}: structural integrity of an installed engine. */
+export type VerifyResult = {
+  readonly id: string;
+  readonly ok: boolean;
+  readonly problems: string[];
+};
+
+/**
+ * Structurally verify an installed engine: the marker is present, `engine.json`
+ * parses and its id matches the dir, and the declared `soname` exists in `lib/`.
+ */
+export const verifyEngine = (root: string, id: string): VerifyResult => {
+  const problems: string[] = [];
+  const dir = engineDir(root, id);
+  if (!existsSync(dir)) {
+    return { id, ok: false, problems: [`not installed (no directory ${dir})`] };
+  }
+  if (!isInstalled(root, id)) {
+    problems.push('missing INSTALLATION_COMPLETE marker (incomplete install)');
+  }
+  try {
+    const manifest = readEngineManifest(dir);
+    if (manifest.id !== id) {
+      problems.push(`engine.json id ${manifest.id} does not match dir ${id}`);
+    }
+    if (!existsSync(join(dir, 'lib', manifest.soname))) {
+      problems.push(`missing lib/${manifest.soname}`);
+    }
+  } catch (error) {
+    problems.push(error instanceof Error ? error.message : String(error));
+  }
+  return { id, ok: problems.length === 0, problems };
 };
 
 /** Injectable side effects for {@link gc}. */

--- a/src/cli/engine-store.ts
+++ b/src/cli/engine-store.ts
@@ -1,0 +1,265 @@
+/**
+ * The shared, content-addressed WebKit engine store — Bunmaska's "tested ==
+ * shipped" mechanism, modelled on Playwright's browser registry (NOT nvm).
+ *
+ * Many engine versions live side by side under `~/.bunmaska/webkit/<engine-id>/`;
+ * every installed app records the exact id it was built against and resolves
+ * THAT id at launch, so different apps pin different WebKit versions and run
+ * simultaneously. There is no global "current" engine. A store dir is kept iff
+ * some installed app (a `.links/*` refcount entry) still needs it.
+ *
+ * Integrity follows Playwright's marker scheme: a fully + correctly installed
+ * engine is the one with an `INSTALLATION_COMPLETE` marker, written LAST after
+ * the content hash verifies — a half-download has no marker and is re-fetched.
+ *
+ * The mutating operations take an explicit `root` (the `webkit/` dir) so they
+ * are testable against a temp dir with no global env mutation; `enginesPath`
+ * computes the real default root from the environment.
+ */
+
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+  writeSync,
+} from 'node:fs';
+import { createHash } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { BunmaskaError } from '../common/errors';
+import { contentHash } from '../common/manifest';
+
+/** The marker file proving an engine dir is fully + correctly installed. */
+export const INSTALLATION_COMPLETE = 'INSTALLATION_COMPLETE';
+const LINKS_DIR = '.links';
+const LOCK_FILE = '__dirlock';
+const STALE_LOCK_MS = 30_000;
+const LOCK_RETRY_MS = 5;
+const LOCK_TIMEOUT_MS = 10_000;
+
+/** Environment slice the default-path resolution reads. */
+export type StoreEnv = Record<string, string | undefined>;
+
+/** The default home dir of the store: `$BUNMASKA_HOME` or `~/.bunmaska`. */
+const defaultHome = (env: StoreEnv): string =>
+  env['BUNMASKA_HOME'] ?? join(env['HOME'] ?? env['USERPROFILE'] ?? homedir(), '.bunmaska');
+
+/**
+ * The engine store root (`webkit/` dir): `$BUNMASKA_ENGINES_PATH`, else
+ * `<home>/webkit`. The single env-reading function — all other ops take `root`.
+ */
+export const enginesPath = (env: StoreEnv = process.env): string =>
+  env['BUNMASKA_ENGINES_PATH'] ?? join(defaultHome(env), 'webkit');
+
+/** Absolute dir of one engine id under the store root. */
+export const engineDir = (root: string, id: string): string => join(root, id);
+
+/** Absolute path of an engine's installation marker. */
+export const markerPath = (root: string, id: string): string =>
+  join(root, id, INSTALLATION_COMPLETE);
+
+/** Refcount link-file path for an installed app (stable hash of its install path). */
+export const linkPath = (root: string, appPath: string): string =>
+  join(root, LINKS_DIR, createHash('sha1').update(appPath).digest('hex'));
+
+/** Absolute path of the cross-process store lock. */
+export const lockPath = (root: string): string => join(root, LOCK_FILE);
+
+/** Whether an engine id is fully installed (has its `INSTALLATION_COMPLETE` marker). */
+export const isInstalled = (root: string, id: string): boolean => existsSync(markerPath(root, id));
+
+/** The installed (marker-complete) engine ids in the store, sorted. */
+export const listInstalled = (root: string): string[] => {
+  if (!existsSync(root)) {
+    return [];
+  }
+  return readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && !entry.name.startsWith('.'))
+    .map((entry) => entry.name)
+    .filter((name) => isInstalled(root, name))
+    .sort();
+};
+
+/** A refcount entry: which engine id an installed app needs. */
+export type EngineLink = { readonly app: string; readonly engine: string };
+
+/** Register an installed app as needing `engineId` (a refcount entry). */
+export const linkApp = (root: string, appPath: string, engineId: string): void => {
+  mkdirSync(join(root, LINKS_DIR), { recursive: true });
+  writeFileSync(linkPath(root, appPath), JSON.stringify({ app: appPath, engine: engineId }));
+};
+
+/** Drop an app's refcount entry (e.g. on uninstall). */
+export const unlinkApp = (root: string, appPath: string): void => {
+  rmSync(linkPath(root, appPath), { force: true });
+};
+
+/** Read every refcount entry. Malformed entries are skipped. */
+export const readLinks = (root: string): EngineLink[] => {
+  const dir = join(root, LINKS_DIR);
+  if (!existsSync(dir)) {
+    return [];
+  }
+  const links: EngineLink[] = [];
+  for (const name of readdirSync(dir)) {
+    try {
+      const raw = JSON.parse(readFileSync(join(dir, name), 'utf8')) as Partial<EngineLink>;
+      if (typeof raw.app === 'string' && typeof raw.engine === 'string') {
+        links.push({ app: raw.app, engine: raw.engine });
+      }
+    } catch {
+      // Skip an unreadable/corrupt link entry rather than failing GC.
+    }
+  }
+  return links;
+};
+
+/** A self-describing engine artifact to install: bytes + the hash its manifest claims. */
+export type InstallSource = {
+  readonly id: string;
+  readonly bytes: Uint8Array;
+  readonly expectedHash: string;
+};
+
+/** Injectable side effects for {@link installFromSource}. */
+export type InstallDeps = {
+  /** Populate `destDir` with the engine tree (`lib/`, `engine.json`) from the bytes. */
+  readonly extract: (bytes: Uint8Array, destDir: string) => Promise<void>;
+  /** Hook fired immediately after the marker is written (test seam for ordering). */
+  readonly onMarker?: () => void;
+};
+
+/** Outcome of an install attempt. */
+export type InstallResult = { readonly id: string; readonly installed: boolean };
+
+/**
+ * Install one engine from its artifact bytes: verify the content hash, extract
+ * to a temp staging dir, atomically swap it into place, then write the marker
+ * LAST. Idempotent — a fully-installed id is left untouched. A hash mismatch
+ * throws and leaves no engine dir behind.
+ */
+export const installFromSource = async (
+  root: string,
+  source: InstallSource,
+  deps: InstallDeps,
+): Promise<InstallResult> => {
+  if (isInstalled(root, source.id)) {
+    return { id: source.id, installed: false };
+  }
+  const actual = contentHash(source.bytes);
+  if (actual !== source.expectedHash) {
+    throw new BunmaskaError(
+      `engine ${source.id}: integrity check failed — hash ${actual} != expected ${source.expectedHash}`,
+      { code: 'ERR_ENGINE_INTEGRITY' },
+    );
+  }
+  mkdirSync(root, { recursive: true });
+  const staging = mkdtempSync(join(root, '.tmp-'));
+  try {
+    await deps.extract(source.bytes, staging);
+    const dest = engineDir(root, source.id);
+    rmSync(dest, { recursive: true, force: true }); // clear any partial prior install
+    renameSync(staging, dest);
+    writeFileSync(markerPath(root, source.id), `${new Date().toISOString()}\n`);
+    deps.onMarker?.();
+    return { id: source.id, installed: true };
+  } catch (error) {
+    rmSync(staging, { recursive: true, force: true });
+    throw error;
+  }
+};
+
+/** Injectable side effects for {@link gc}. */
+export type GcDeps = {
+  /** Whether an app's install path still exists (default: real fs check). */
+  readonly exists?: (appPath: string) => boolean;
+  /** Report only; delete nothing. */
+  readonly dryRun?: boolean;
+};
+
+/** What {@link gc} kept, removed, and how many dead-app links it dropped. */
+export type GcResult = {
+  readonly kept: string[];
+  readonly removed: string[];
+  readonly droppedLinks: number;
+};
+
+/**
+ * Garbage-collect the store: an engine is kept iff some live app still links it.
+ * Links whose app no longer exists are dropped first (freeing their engines).
+ * With `dryRun`, nothing is mutated — the result reports what WOULD be removed.
+ */
+export const gc = async (root: string, deps: GcDeps = {}): Promise<GcResult> => {
+  const exists = deps.exists ?? existsSync;
+  const dryRun = deps.dryRun === true;
+  let droppedLinks = 0;
+  const used = new Set<string>();
+  for (const link of readLinks(root)) {
+    if (exists(link.app)) {
+      used.add(link.engine);
+    } else {
+      droppedLinks += 1;
+      if (!dryRun) {
+        unlinkApp(root, link.app);
+      }
+    }
+  }
+  const installed = listInstalled(root);
+  const removed = installed.filter((id) => !used.has(id)).sort();
+  const kept = installed.filter((id) => used.has(id)).sort();
+  if (!dryRun) {
+    for (const id of removed) {
+      rmSync(engineDir(root, id), { recursive: true, force: true });
+    }
+  }
+  return { kept, removed, droppedLinks };
+};
+
+const sleep = (ms: number): Promise<void> => Bun.sleep(ms);
+
+/**
+ * Run `fn` while holding the store's cross-process lock. Acquires by exclusive
+ * file create, retries while another holder is live, steals a stale lock, and
+ * always releases — even if `fn` throws.
+ */
+export const withLock = async <T>(root: string, fn: () => Promise<T>): Promise<T> => {
+  mkdirSync(root, { recursive: true });
+  const lock = lockPath(root);
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  for (;;) {
+    try {
+      const fd = openSync(lock, 'wx');
+      writeSync(fd, String(process.pid));
+      closeSync(fd);
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+        throw error;
+      }
+      const age = Date.now() - statSync(lock).mtimeMs;
+      if (age > STALE_LOCK_MS) {
+        rmSync(lock, { force: true }); // steal a stale lock
+        continue;
+      }
+      if (Date.now() > deadline) {
+        throw new BunmaskaError(`engine store: timed out acquiring lock at ${lock}`, {
+          code: 'ERR_ENGINE_LOCK',
+        });
+      }
+      await sleep(LOCK_RETRY_MS);
+    }
+  }
+  try {
+    return await fn();
+  } finally {
+    rmSync(lock, { force: true });
+  }
+};

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,7 +7,7 @@
  * `process.stdout`/`process.stderr` because Biome bans `console.*`.
  */
 
-import { buildLinuxApp } from './build-linux';
+import { buildLinuxApp, resolveBuildEngineId } from './build-linux';
 import {
   type BuildDmg,
   type BuildMacAppOptions,
@@ -173,9 +173,21 @@ const runBuild = async (
 
   const name = command.options.name ?? deriveName(command.entry);
   if (target === 'linux') {
+    const { config } = await loadConfig(process.cwd());
+    const webkitPin = config.engine?.webkit;
+    const engineId = resolveBuildEngineId(webkitPin);
+    if (webkitPin !== undefined && engineId === 'system' && webkitPin !== 'system') {
+      err(
+        `bunmaska build: engine pin ${JSON.stringify(webkitPin)} is a bare version; ` +
+          'resolving it to a full engine-id needs the engine catalog (a follow-up). ' +
+          'Baking the system WebKit for now.',
+      );
+    }
     const result = await buildLinuxApp({
       entry: command.entry,
       name,
+      engineId,
+      ...(config.engine?.embed === true ? { embedEngine: true } : {}),
       ...(command.options.id !== undefined ? { id: command.options.id } : {}),
       ...(command.options.out !== undefined ? { out: command.options.out } : {}),
       ...(command.options.icon !== undefined ? { icon: command.options.icon } : {}),

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,6 +18,8 @@ import {
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { loadConfig } from './config';
+import { runDoctor, runEngine } from './engine-command';
+import { enginesPath } from './engine-store';
 import { resolveDevEntry, runDev } from './dev';
 import { runInit } from './init';
 import {
@@ -48,8 +50,18 @@ Usage:
   bunmaska dev [entry.ts]                Run the app, restarting on file changes
   bunmaska run <entry.ts> [args...]      Launch a Bunmaska app (bun run <entry>)
   bunmaska build <entry.ts> [options]    Bundle a distributable app
+  bunmaska engine <subcommand>           Manage the pinned-WebKit engine store
+  bunmaska doctor [dir]                   Report runtime, store, and the engine pin
   bunmaska --help                        Show this help
   bunmaska --version                     Print the Bunmaska version
+
+engine subcommands:
+  list                  Installed engines (side by side) and their refcounts
+  which [dir]           The engine-id a project resolves (defaults to system)
+  install <path>        Install a local engine directory into the shared store
+  use <id> [--for dir]  Pin an engine per-project (there is no global switch)
+  prune [--dry-run]     Garbage-collect engines no installed app references
+  verify <id>           Structurally verify an installed engine
 
 build options:
   --target <os>      Build target: macos | linux (default: host platform)
@@ -243,6 +255,15 @@ const runInitCommand = (command: Extract<Command, { kind: 'init' }>): number => 
   return 0;
 };
 
+/** Shared dependencies for the `engine`/`doctor` commands (real store + config). */
+const engineCommandDeps = (): Parameters<typeof runEngine>[1] => ({
+  root: enginesPath(),
+  env: process.env,
+  out,
+  err,
+  readConfig: async (target) => (await loadConfig(target)).config,
+});
+
 /** Block until SIGINT/SIGTERM, then run `stop` and resolve. */
 const awaitInterrupt = (stop: () => void): Promise<void> =>
   new Promise<void>((resolvePromise) => {
@@ -286,6 +307,10 @@ export const dispatch = async (command: Command, deps: DispatchDeps = {}): Promi
       return await runApp(command.entry, command.args);
     case 'build':
       return await runBuild(command, deps);
+    case 'engine':
+      return await runEngine(command.sub, engineCommandDeps());
+    case 'doctor':
+      return await runDoctor(command.target, engineCommandDeps());
     case 'error':
       err(command.message);
       err('');

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -61,6 +61,7 @@ engine subcommands:
   install <path>        Install a local engine directory into the shared store
   use <id> [--for dir]  Pin an engine per-project (there is no global switch)
   prune [--dry-run]     Garbage-collect engines no installed app references
+                        (use --force to prune when no app has registered yet)
   verify <id>           Structurally verify an installed engine
 
 build options:

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -37,7 +37,7 @@ export type EngineSubcommand =
   | { readonly action: 'which'; readonly target?: string }
   | { readonly action: 'install'; readonly source: string }
   | { readonly action: 'use'; readonly id: string; readonly for?: string }
-  | { readonly action: 'prune'; readonly dryRun: boolean }
+  | { readonly action: 'prune'; readonly dryRun: boolean; readonly force: boolean }
   | { readonly action: 'verify'; readonly id: string };
 
 export type Command =
@@ -205,7 +205,14 @@ const parseEngine = (rest: readonly string[]): Command => {
       };
     }
     case 'prune':
-      return { kind: 'engine', sub: { action: 'prune', dryRun: args.includes('--dry-run') } };
+      return {
+        kind: 'engine',
+        sub: {
+          action: 'prune',
+          dryRun: args.includes('--dry-run'),
+          force: args.includes('--force'),
+        },
+      };
     case 'verify': {
       const id = args[0];
       if (id === undefined) {

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -31,6 +31,15 @@ export type BuildOptions = {
   readonly update?: boolean;
 };
 
+/** Subcommands of `bunmaska engine`, for managing the pinned-WebKit store. */
+export type EngineSubcommand =
+  | { readonly action: 'list' }
+  | { readonly action: 'which'; readonly target?: string }
+  | { readonly action: 'install'; readonly source: string }
+  | { readonly action: 'use'; readonly id: string; readonly for?: string }
+  | { readonly action: 'prune'; readonly dryRun: boolean }
+  | { readonly action: 'verify'; readonly id: string };
+
 export type Command =
   | { readonly kind: 'help' }
   | { readonly kind: 'version' }
@@ -38,6 +47,8 @@ export type Command =
   | { readonly kind: 'dev'; readonly entry?: string }
   | { readonly kind: 'run'; readonly entry: string; readonly args: readonly string[] }
   | { readonly kind: 'build'; readonly entry: string; readonly options: BuildOptions }
+  | { readonly kind: 'engine'; readonly sub: EngineSubcommand }
+  | { readonly kind: 'doctor'; readonly target?: string }
   | { readonly kind: 'error'; readonly message: string };
 
 /** `bunmaska build` flags that take a string value, keyed by argv token. */
@@ -146,6 +157,67 @@ const parseBuild = (rest: readonly string[]): Command => {
   return { kind: 'build', entry, options };
 };
 
+/** Parse the `bunmaska engine <action> …` tail into a {@link Command}. */
+const parseEngine = (rest: readonly string[]): Command => {
+  const [action, ...args] = rest;
+  if (action === undefined) {
+    return { kind: 'error', message: 'bunmaska engine: missing subcommand' };
+  }
+  switch (action) {
+    case 'list':
+      return { kind: 'engine', sub: { action: 'list' } };
+    case 'which': {
+      const target = args[0];
+      return {
+        kind: 'engine',
+        sub: target === undefined ? { action: 'which' } : { action: 'which', target },
+      };
+    }
+    case 'install': {
+      const source = args[0];
+      if (source === undefined) {
+        return { kind: 'error', message: 'bunmaska engine install: missing <id|path>' };
+      }
+      return { kind: 'engine', sub: { action: 'install', source } };
+    }
+    case 'use': {
+      const id = args[0];
+      if (id === undefined) {
+        return { kind: 'error', message: 'bunmaska engine use: missing <engine-id>' };
+      }
+      let forDir: string | undefined;
+      for (let i = 1; i < args.length; i += 1) {
+        const token = args[i];
+        if (token === '--for') {
+          const value = args[i + 1];
+          if (value === undefined) {
+            return { kind: 'error', message: 'bunmaska engine use: --for requires a directory' };
+          }
+          forDir = value;
+          i += 1;
+          continue;
+        }
+        return { kind: 'error', message: `bunmaska engine use: unexpected argument ${token}` };
+      }
+      return {
+        kind: 'engine',
+        sub: forDir === undefined ? { action: 'use', id } : { action: 'use', id, for: forDir },
+      };
+    }
+    case 'prune':
+      return { kind: 'engine', sub: { action: 'prune', dryRun: args.includes('--dry-run') } };
+    case 'verify': {
+      const id = args[0];
+      if (id === undefined) {
+        return { kind: 'error', message: 'bunmaska engine verify: missing <engine-id>' };
+      }
+      return { kind: 'engine', sub: { action: 'verify', id } };
+    }
+    default:
+      return { kind: 'error', message: `bunmaska engine: unknown subcommand '${action}'` };
+  }
+};
+
 /** Parse the argv tail into a {@link Command}. Never throws. */
 export const parseArgs = (argv: readonly string[]): Command => {
   const [head, ...rest] = argv;
@@ -166,6 +238,13 @@ export const parseArgs = (argv: readonly string[]): Command => {
   }
   if (head === 'build') {
     return parseBuild(rest);
+  }
+  if (head === 'engine') {
+    return parseEngine(rest);
+  }
+  if (head === 'doctor') {
+    const target = rest[0];
+    return target === undefined ? { kind: 'doctor' } : { kind: 'doctor', target };
   }
   return { kind: 'error', message: `bunmaska: unknown command '${head}'` };
 };

--- a/src/common/config-schema.ts
+++ b/src/common/config-schema.ts
@@ -17,6 +17,22 @@ export type BunmaskaUpdatesConfig = {
   readonly channel?: Channel;
 };
 
+/**
+ * Pinned-WebKit engine configuration — the "tested == shipped" knob. Many engine
+ * versions coexist in the shared store; this declares which one THIS app pins.
+ */
+export type BunmaskaEngineConfig = {
+  /**
+   * The WebKit engine to pin: a full engine-id
+   * (`webkitgtk-6.0-2.52.4-bunmaska1-linux-x64`), a bare upstream version
+   * (`2.52.4`, resolved to the host's id at build time), or `system` (the
+   * default — use the OS WebView, no pinning).
+   */
+  readonly webkit?: string;
+  /** Copy the pinned engine into the bundle for offline/airgapped installs. */
+  readonly embed?: boolean;
+};
+
 /** A project's `bunmaska.config` shape. Every field is optional. */
 export type BunmaskaConfig = {
   /** Display/bundle name. */
@@ -29,6 +45,8 @@ export type BunmaskaConfig = {
   readonly icon?: string;
   /** Auto-update feed configuration. */
   readonly updates?: BunmaskaUpdatesConfig;
+  /** Pinned-WebKit engine configuration (defaults to the system WebView). */
+  readonly engine?: BunmaskaEngineConfig;
 };
 
 /** The config file names searched for, in priority order. */
@@ -54,6 +72,20 @@ const assertOptionalString = (
   }
   if (typeof value !== 'string') {
     throw new InvalidArgumentError(`${source}: "${field}" must be a string`);
+  }
+  return value;
+};
+
+const assertOptionalBoolean = (
+  value: unknown,
+  field: string,
+  source: string,
+): boolean | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'boolean') {
+    throw new InvalidArgumentError(`${source}: "${field}" must be a boolean`);
   }
   return value;
 };
@@ -98,6 +130,20 @@ export const validateConfig = (raw: unknown, source = 'bunmaska.config'): Bunmas
     config.updates = {
       ...(url !== undefined ? { url } : {}),
       ...(channel !== undefined ? { channel } : {}),
+    };
+  }
+
+  const engine = record['engine'];
+  if (engine !== undefined) {
+    if (engine === null || typeof engine !== 'object') {
+      throw new InvalidArgumentError(`${source}: "engine" must be an object`);
+    }
+    const engineRecord = engine as Record<string, unknown>;
+    const webkit = assertOptionalString(engineRecord['webkit'], 'engine.webkit', source);
+    const embed = assertOptionalBoolean(engineRecord['embed'], 'engine.embed', source);
+    config.engine = {
+      ...(webkit !== undefined ? { webkit } : {}),
+      ...(embed !== undefined ? { embed } : {}),
     };
   }
 

--- a/src/common/engine-id.ts
+++ b/src/common/engine-id.ts
@@ -1,0 +1,139 @@
+/**
+ * The WebKit engine-id: the content address of one pinned engine build, and the
+ * single source of truth for how Bunmaska names engines on disk.
+ *
+ * The store keys directories on this id so that MANY engine versions coexist
+ * side by side (Playwright's browser-registry model), and every app resolves the
+ * exact id it was built against — there is no global "current" engine. The
+ * WebKitGTK 6.0 soname (`libwebkitgtk-6.0.so.4`) is shared across every upstream
+ * release, so the soname cannot identify a version; the id encodes the full
+ * upstream version + our build revision instead.
+ *
+ * Format: a flat, all-dash, six-field string where NO field may contain a dash,
+ * so it splits unambiguously: `<engine>-<api>-<upstream>-<rev>-<os>-<arch>`
+ * (e.g. `webkitgtk-6.0-2.52.4-bunmaska1-linux-x64`). `'system'` is a reserved
+ * sentinel — "use the OS WebView", the default — and is never a parseable id.
+ */
+
+import { InvalidArgumentError } from './errors';
+import { compareVersions } from './manifest';
+import type { Arch } from './platform';
+
+/** Which web-engine family a build belongs to. */
+export type EngineFamily = 'webkitgtk' | 'webkit' | 'webview2';
+
+/** The OS an engine binary targets. Windows is reserved ahead of its backend. */
+export type EngineOs = 'linux' | 'macos' | 'windows';
+
+/** The structured form of an engine-id. */
+export type EngineRef = {
+  readonly engine: EngineFamily;
+  /** API/soname generation, e.g. `6.0`. */
+  readonly api: string;
+  /** Upstream WebKit release, e.g. `2.52.4` (dotted numeric). */
+  readonly upstream: string;
+  /** Bunmaska build revision of that upstream, e.g. `bunmaska1`. */
+  readonly rev: string;
+  readonly os: EngineOs;
+  readonly arch: Arch;
+};
+
+/** The reserved sentinel meaning "use the OS WebView" (the default). */
+export const SYSTEM_ENGINE = 'system';
+
+const ENGINE_FAMILIES: ReadonlySet<string> = new Set(['webkitgtk', 'webkit', 'webview2']);
+const ENGINE_OSES: ReadonlySet<string> = new Set(['linux', 'macos', 'windows']);
+const ENGINE_ARCHES: ReadonlySet<string> = new Set(['x64', 'arm64']);
+
+/** Whether `id` is the reserved system sentinel (case-insensitive). */
+export const isSystemEngine = (id: string): boolean => id.trim().toLowerCase() === SYSTEM_ENGINE;
+
+const assertNoDash = (value: string, field: string): void => {
+  if (value.length === 0 || value.includes('-')) {
+    throw new InvalidArgumentError(
+      `engine-id: "${field}" must be non-empty and contain no dash (got ${JSON.stringify(value)})`,
+    );
+  }
+};
+
+/** Format an {@link EngineRef} into its flat engine-id string. Throws on a dashed field. */
+export const formatEngineId = (ref: EngineRef): string => {
+  assertNoDash(ref.api, 'api');
+  assertNoDash(ref.upstream, 'upstream');
+  assertNoDash(ref.rev, 'rev');
+  return `${ref.engine}-${ref.api}-${ref.upstream}-${ref.rev}-${ref.os}-${ref.arch}`;
+};
+
+/**
+ * Parse a flat engine-id back into an {@link EngineRef}, validating every field.
+ * Throws {@link InvalidArgumentError} on the system sentinel or any malformed id.
+ */
+export const parseEngineId = (id: string): EngineRef => {
+  const parts = id.split('-');
+  if (parts.length !== 6) {
+    throw new InvalidArgumentError(
+      `engine-id: expected 6 dash-separated fields, got ${parts.length} in ${JSON.stringify(id)}`,
+    );
+  }
+  const [engine, api, upstream, rev, os, arch] = parts as [
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+  ];
+  if (!ENGINE_FAMILIES.has(engine)) {
+    throw new InvalidArgumentError(`engine-id: unknown engine family ${JSON.stringify(engine)}`);
+  }
+  if (!ENGINE_OSES.has(os)) {
+    throw new InvalidArgumentError(`engine-id: unknown os ${JSON.stringify(os)}`);
+  }
+  if (!ENGINE_ARCHES.has(arch)) {
+    throw new InvalidArgumentError(`engine-id: unknown arch ${JSON.stringify(arch)}`);
+  }
+  if (!/^[0-9]+(\.[0-9]+)*$/.test(upstream)) {
+    throw new InvalidArgumentError(
+      `engine-id: upstream must be a dotted numeric version (got ${JSON.stringify(upstream)})`,
+    );
+  }
+  if (api.length === 0 || rev.length === 0) {
+    throw new InvalidArgumentError('engine-id: api and rev must be non-empty');
+  }
+  return {
+    engine: engine as EngineFamily,
+    api,
+    upstream,
+    rev,
+    os: os as EngineOs,
+    arch: arch as Arch,
+  };
+};
+
+/** Numeric order of a build revision's trailing counter (`bunmaska10` -> 10), or NaN. */
+const revOrder = (rev: string): number => {
+  const match = rev.match(/(\d+)$/);
+  return match ? Number(match[1]) : Number.NaN;
+};
+
+/**
+ * Compare two engine-ids for a deterministic ascending sort: by upstream version
+ * (SemVer-aware), tie-broken by build-revision counter then the raw id string.
+ */
+export const compareEngineIds = (a: string, b: string): -1 | 0 | 1 => {
+  const ra = parseEngineId(a);
+  const rb = parseEngineId(b);
+  const byUpstream = compareVersions(ra.upstream, rb.upstream);
+  if (byUpstream !== 0) {
+    return byUpstream;
+  }
+  const na = revOrder(ra.rev);
+  const nb = revOrder(rb.rev);
+  if (!Number.isNaN(na) && !Number.isNaN(nb) && na !== nb) {
+    return na < nb ? -1 : 1;
+  }
+  if (a === b) {
+    return 0;
+  }
+  return a < b ? -1 : 1;
+};

--- a/src/main/engine/resolve.ts
+++ b/src/main/engine/resolve.ts
@@ -1,0 +1,151 @@
+/**
+ * Launch-time WebKit engine resolution — the runtime half of "tested ==
+ * shipped". Decides, for THIS process, whether to load the OS WebView (the
+ * default) or a pinned engine from the shared store, by reading the engine-id
+ * the app was built against. Pure decision logic over injected seams (env, fs,
+ * the baked-id reader) so it unit-tests on any host; the actual `dlopen` of the
+ * resolved path happens in the Linux loaders.
+ *
+ * Precedence: `BUNMASKA_WEBKIT_PATH` (explicit dir) > `BUNMASKA_WEBKIT_ID` (env
+ * id) > the baked `engine.id` next to the executable > the `system` sentinel.
+ * A pinned id whose store dir lacks its `INSTALLATION_COMPLETE` marker degrades
+ * to the system WebView with a loud warning — the app must still launch, but the
+ * tested==shipped guarantee is explicitly flagged as broken.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { isSystemEngine, parseEngineId } from '../../common/engine-id';
+import {
+  engineDir,
+  enginesPath,
+  INSTALLATION_COMPLETE,
+  type StoreEnv,
+} from '../../cli/engine-store';
+
+/** The resolved engine decision for the current process. */
+export type EngineResolution = {
+  readonly mode: 'system' | 'pinned';
+  /** The pinned engine's `lib/` dir (absolute). Absent in system mode. */
+  readonly libDir?: string;
+  /** Non-fatal warnings to surface on stderr (e.g. a broken pin fell back). */
+  readonly warnings: readonly string[];
+};
+
+/** Injectable seams for {@link resolveEngineWith}. */
+export type ResolveDeps = {
+  readonly env?: StoreEnv;
+  /** Existence check for the marker (default: real fs). */
+  readonly exists?: (path: string) => boolean;
+  /** Read the engine-id baked into the bundle, or null if none. */
+  readonly readBakedId?: () => string | null;
+  /** Override the store root (default: {@link enginesPath} of `env`). */
+  readonly enginesRoot?: string;
+};
+
+/** Default reader for the baked `engine.id`: env override, else beside the executable. */
+const defaultReadBakedId = (env: StoreEnv): string | null => {
+  const explicit = env['BUNMASKA_ENGINE_ID_FILE'];
+  const candidates = explicit ? [explicit] : [join(dirname(process.execPath), 'engine.id')];
+  for (const path of candidates) {
+    try {
+      const value = readFileSync(path, 'utf8').trim();
+      if (value.length > 0) {
+        return value;
+      }
+    } catch {
+      // No baked id at this candidate — try the next.
+    }
+  }
+  return null;
+};
+
+/** Resolve the engine decision from explicit deps. Pure (no ambient globals besides defaults). */
+export const resolveEngineWith = (deps: ResolveDeps = {}): EngineResolution => {
+  const env = deps.env ?? process.env;
+  const exists = deps.exists ?? existsSync;
+
+  const explicitDir = env['BUNMASKA_WEBKIT_PATH'];
+  if (explicitDir !== undefined && explicitDir.length > 0) {
+    return { mode: 'pinned', libDir: explicitDir, warnings: [] };
+  }
+
+  const readBakedId = deps.readBakedId ?? (() => defaultReadBakedId(env));
+  const id = (env['BUNMASKA_WEBKIT_ID'] ?? readBakedId() ?? 'system').trim();
+
+  if (isSystemEngine(id)) {
+    return { mode: 'system', warnings: [] };
+  }
+
+  try {
+    parseEngineId(id); // validate shape; the parsed fields are not needed here
+  } catch {
+    return {
+      mode: 'system',
+      warnings: [
+        `bunmaska: pinned engine id ${JSON.stringify(id)} is malformed — using the system WebKit.`,
+      ],
+    };
+  }
+
+  const root = deps.enginesRoot ?? enginesPath(env);
+  const dir = engineDir(root, id);
+  if (!exists(join(dir, INSTALLATION_COMPLETE))) {
+    return {
+      mode: 'system',
+      warnings: [
+        `bunmaska: pinned engine ${id} is not installed — falling back to the system WebKit; ` +
+          `tested==shipped is not guaranteed. Run \`bunmaska engine install ${id}\` to restore it.`,
+      ],
+    };
+  }
+  return { mode: 'pinned', libDir: join(dir, 'lib'), warnings: [] };
+};
+
+const cache: { value: EngineResolution | undefined } = { value: undefined };
+
+/**
+ * The process-singleton engine resolution. Cached so both Linux loaders (GTK +
+ * WebKitGTK) agree on ONE engine — mixing a system GTK with a pinned WebKit (or
+ * vice-versa) would double-load GTK symbols and crash.
+ */
+export const resolveEngine = (): EngineResolution => {
+  if (cache.value === undefined) {
+    cache.value = resolveEngineWith();
+  }
+  return cache.value;
+};
+
+/** Reset the cached resolution (test seam only). */
+export const resetEngineResolution = (): void => {
+  cache.value = undefined;
+};
+
+/**
+ * The path to pass `dlopen` for one library given a resolution: an absolute path
+ * into the pinned engine's `lib/`, or the bare soname for the system loader path.
+ */
+export const engineLibPath = (resolution: EngineResolution, soname: string): string =>
+  resolution.mode === 'pinned' && resolution.libDir !== undefined
+    ? join(resolution.libDir, soname)
+    : soname;
+
+/**
+ * The environment overrides needed for a pinned engine: prepend its `lib/` to
+ * `LD_LIBRARY_PATH` so its bundled GTK/libsoup/ICU/GStreamer win over the
+ * distro's, and point `GIO_EXTRA_MODULES` at its gio modules. Empty in system mode.
+ */
+export const engineEnv = (
+  resolution: EngineResolution,
+  env: StoreEnv,
+): { LD_LIBRARY_PATH?: string; GIO_EXTRA_MODULES?: string } => {
+  if (resolution.mode !== 'pinned' || resolution.libDir === undefined) {
+    return {};
+  }
+  const prior = env['LD_LIBRARY_PATH'];
+  return {
+    LD_LIBRARY_PATH:
+      prior !== undefined && prior.length > 0 ? `${resolution.libDir}:${prior}` : resolution.libDir,
+    GIO_EXTRA_MODULES: join(resolution.libDir, 'gio', 'modules'),
+  };
+};

--- a/src/main/engine/resolve.ts
+++ b/src/main/engine/resolve.ts
@@ -163,3 +163,38 @@ export const engineEnv = (
     GIO_EXTRA_MODULES: join(resolution.libDir, 'gio', 'modules'),
   };
 };
+
+const prep: { done: boolean } = { done: false };
+
+/**
+ * Apply a resolution to the process before the first `dlopen`: print any
+ * fallback warnings, and (in pinned mode) export `LD_LIBRARY_PATH` /
+ * `GIO_EXTRA_MODULES` so the engine's bundled deps win. Runs once per process —
+ * both Linux loaders (GTK + WebKitGTK) call it, but only the first takes effect,
+ * keeping them on a single shared engine.
+ */
+export const prepareEngineForLoad = (
+  resolution: EngineResolution,
+  target: StoreEnv,
+  write: (text: string) => void,
+): void => {
+  if (prep.done) {
+    return;
+  }
+  prep.done = true;
+  for (const warning of resolution.warnings) {
+    write(`${warning}\n`);
+  }
+  const env = engineEnv(resolution, target);
+  if (env.LD_LIBRARY_PATH !== undefined) {
+    target['LD_LIBRARY_PATH'] = env.LD_LIBRARY_PATH;
+  }
+  if (env.GIO_EXTRA_MODULES !== undefined) {
+    target['GIO_EXTRA_MODULES'] = env.GIO_EXTRA_MODULES;
+  }
+};
+
+/** Reset the one-shot preparation guard (test seam only). */
+export const resetEnginePreparation = (): void => {
+  prep.done = false;
+};

--- a/src/main/engine/resolve.ts
+++ b/src/main/engine/resolve.ts
@@ -14,7 +14,7 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { isSystemEngine, parseEngineId } from '../../common/engine-id';
 import {
   engineDir,
@@ -43,10 +43,24 @@ export type ResolveDeps = {
   readonly enginesRoot?: string;
 };
 
+/**
+ * Candidate paths for the baked `engine.id`, in priority order: the explicit env
+ * override, then the install layout `usr/share/<slug>/engine.id` (relative to the
+ * executable at `usr/bin/<slug>`), then a flat sibling fallback. Pure + testable.
+ */
+export const bakedIdCandidates = (execPath: string, env: StoreEnv): string[] => {
+  const explicit = env['BUNMASKA_ENGINE_ID_FILE'];
+  if (explicit !== undefined && explicit.length > 0) {
+    return [explicit];
+  }
+  const dir = dirname(execPath); // .../usr/bin
+  const slug = basename(execPath);
+  return [join(dir, '..', 'share', slug, 'engine.id'), join(dir, 'engine.id')];
+};
+
 /** Default reader for the baked `engine.id`: env override, else beside the executable. */
 const defaultReadBakedId = (env: StoreEnv): string | null => {
-  const explicit = env['BUNMASKA_ENGINE_ID_FILE'];
-  const candidates = explicit ? [explicit] : [join(dirname(process.execPath), 'engine.id')];
+  const candidates = bakedIdCandidates(process.execPath, env);
   for (const path of candidates) {
     try {
       const value = readFileSync(path, 'utf8').trim();

--- a/src/main/platform/linux/gtk-ffi.ts
+++ b/src/main/platform/linux/gtk-ffi.ts
@@ -1,6 +1,7 @@
 import { dlopen, FFIType } from 'bun:ffi';
 import { UnsupportedPlatformError } from '../../../common/errors';
 import { currentPlatform } from '../../../common/platform';
+import { engineLibPath, prepareEngineForLoad, resolveEngine } from '../../engine/resolve';
 
 const LIBGTK_PATH = 'libgtk-4.so.1';
 
@@ -154,7 +155,13 @@ export const loadGtkFFI = () => {
   if (cache.ffi) {
     return cache.ffi;
   }
-  const ffi = dlopen(LIBGTK_PATH, GTK_FFI_SYMBOLS);
+  // Share the engine resolution with the WebKitGTK loader: in pinned mode GTK
+  // must come from the SAME store `lib/` as WebKit, or two GTK symbol sets land
+  // in one process and crash. `prepareEngineForLoad` is a one-shot no-op after
+  // the first loader, so whichever fires first fixes the engine for both.
+  const engine = resolveEngine();
+  prepareEngineForLoad(engine, process.env, (text) => process.stderr.write(text));
+  const ffi = dlopen(engineLibPath(engine, LIBGTK_PATH), GTK_FFI_SYMBOLS);
   cache.ffi = ffi;
   return ffi;
 };

--- a/src/main/platform/linux/webkitgtk-ffi.ts
+++ b/src/main/platform/linux/webkitgtk-ffi.ts
@@ -1,6 +1,7 @@
 import { CString, dlopen, FFIType, type Pointer } from 'bun:ffi';
 import { UnsupportedPlatformError } from '../../../common/errors';
 import { currentPlatform } from '../../../common/platform';
+import { engineLibPath, prepareEngineForLoad, resolveEngine } from '../../engine/resolve';
 
 /**
  * Loads WebKitGTK 6.0 — the Linux system-WebKit web view (the role
@@ -238,7 +239,12 @@ export const loadWebKitGtkFFI = () => {
   if (cache.ffi) {
     return cache.ffi;
   }
-  const ffi = dlopen(LIBWEBKITGTK_PATH, WEBKITGTK_FFI_SYMBOLS);
+  // Resolve the pinned engine (if any) before dlopen, so a `bunmaska build`-baked
+  // engine-id loads its own WebKitGTK from the shared store instead of the
+  // system soname. System mode (the default) passes the bare soname through.
+  const engine = resolveEngine();
+  prepareEngineForLoad(engine, process.env, (text) => process.stderr.write(text));
+  const ffi = dlopen(engineLibPath(engine, LIBWEBKITGTK_PATH), WEBKITGTK_FFI_SYMBOLS);
   cache.ffi = ffi;
   return ffi;
 };

--- a/tests/unit/cli/build-linux.test.ts
+++ b/tests/unit/cli/build-linux.test.ts
@@ -3,9 +3,13 @@ import {
   buildControlFile,
   buildDesktopEntry,
   debFileName,
+  DEFAULT_LINUX_DEPENDS,
   linuxLayout,
+  resolveBuildEngineId,
   tarballName,
 } from '../../../src/cli/build-linux';
+
+const ENGINE_ID = 'webkitgtk-6.0-2.52.4-bunmaska1-linux-x64';
 
 describe('linuxLayout', () => {
   const layout = linuxLayout('/tmp/out', 'My App');
@@ -28,6 +32,10 @@ describe('linuxLayout', () => {
 
   test('places the icon under hicolor/512x512/apps', () => {
     expect(layout.iconPath).toBe('/tmp/out/My App/usr/share/icons/hicolor/512x512/apps/my-app.png');
+  });
+
+  test('bakes engine.id under usr/share/<slug>', () => {
+    expect(layout.engineIdPath).toBe('/tmp/out/My App/usr/share/my-app/engine.id');
   });
 });
 
@@ -96,5 +104,44 @@ describe('buildControlFile', () => {
 
   test('ends with a trailing newline', () => {
     expect(text.endsWith('\n')).toBe(true);
+  });
+
+  test('emits a Depends line on the system WebKitGTK when given deps (the bug fix)', () => {
+    const withDeps = buildControlFile({
+      slug: 'my-app',
+      version: '1.0.0',
+      maintainer: 'Bunmaska <noreply@bunmaska.dev>',
+      description: 'My App built with Bunmaska',
+      depends: DEFAULT_LINUX_DEPENDS,
+    });
+    expect(withDeps).toContain('Depends: libwebkitgtk-6.0-4, libgtk-4-1');
+    // Depends precedes Description (Debian field ordering).
+    expect(withDeps.indexOf('Depends:')).toBeLessThan(withDeps.indexOf('Description:'));
+  });
+
+  test('omits the Depends field entirely when deps are empty (embedded engine)', () => {
+    const noDeps = buildControlFile({
+      slug: 'my-app',
+      version: '1.0.0',
+      maintainer: 'Bunmaska <noreply@bunmaska.dev>',
+      description: 'x',
+      depends: [],
+    });
+    expect(noDeps).not.toContain('Depends:');
+  });
+});
+
+describe('resolveBuildEngineId', () => {
+  test('passes a full engine-id through', () => {
+    expect(resolveBuildEngineId(ENGINE_ID)).toBe(ENGINE_ID);
+  });
+
+  test('maps absent / system to the system sentinel', () => {
+    expect(resolveBuildEngineId(undefined)).toBe('system');
+    expect(resolveBuildEngineId('system')).toBe('system');
+  });
+
+  test('downgrades a bare upstream version to system (catalog is a follow-up)', () => {
+    expect(resolveBuildEngineId('2.52.4')).toBe('system');
   });
 });

--- a/tests/unit/cli/engine-command.test.ts
+++ b/tests/unit/cli/engine-command.test.ts
@@ -134,9 +134,29 @@ describe('engine prune', () => {
     const root = makeTmpDir();
     await installFromDir(root, makeEngineDir(root, ID));
     const c = capture(root);
-    await runEngine({ action: 'prune', dryRun: true }, c.deps);
+    await runEngine({ action: 'prune', dryRun: true, force: false }, c.deps);
     expect(c.text()).toMatch(/dry run/i);
     expect(c.text()).toContain(ID);
+    expect(c.deps.root && (await import('node:fs')).existsSync(`${root}/${ID}`)).toBeTruthy();
+  });
+
+  test('refuses to wipe the whole store when no app has registered (no --force)', async () => {
+    const root = makeTmpDir();
+    await installFromDir(root, makeEngineDir(root, ID));
+    const c = capture(root);
+    await runEngine({ action: 'prune', dryRun: false, force: false }, c.deps);
+    expect(c.text()).toMatch(/Refusing to prune/);
+    const { existsSync } = await import('node:fs');
+    expect(existsSync(`${root}/${ID}`)).toBe(true);
+  });
+
+  test('--force prunes the unreferenced engine', async () => {
+    const root = makeTmpDir();
+    await installFromDir(root, makeEngineDir(root, ID));
+    const c = capture(root);
+    await runEngine({ action: 'prune', dryRun: false, force: true }, c.deps);
+    const { existsSync } = await import('node:fs');
+    expect(existsSync(`${root}/${ID}`)).toBe(false);
   });
 });
 

--- a/tests/unit/cli/engine-command.test.ts
+++ b/tests/unit/cli/engine-command.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { BunmaskaConfig } from '../../../src/common/config-schema';
+import { runDoctor, runEngine } from '../../../src/cli/engine-command';
+import { installFromDir, linkApp } from '../../../src/cli/engine-store';
+
+const ID = 'webkitgtk-6.0-2.52.4-bunmaska1-linux-x64';
+const ID2 = 'webkitgtk-6.0-2.46.0-bunmaska1-linux-x64';
+
+const tmpDirs: string[] = [];
+const makeTmpDir = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'bunmaska-cmd-'));
+  tmpDirs.push(dir);
+  return dir;
+};
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const makeEngineDir = (parent: string, id: string): string => {
+  const dir = join(parent, `src-${id}`);
+  mkdirSync(join(dir, 'lib'), { recursive: true });
+  writeFileSync(join(dir, 'lib', 'libwebkitgtk-6.0.so.4'), 'SO');
+  writeFileSync(join(dir, 'engine.json'), JSON.stringify({ id, soname: 'libwebkitgtk-6.0.so.4' }));
+  return dir;
+};
+
+type Captured = {
+  readonly deps: Parameters<typeof runEngine>[1];
+  readonly out: string[];
+  readonly err: string[];
+  text: () => string;
+};
+const capture = (root: string, config: BunmaskaConfig = {}): Captured => {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    out,
+    err,
+    text: () => out.join('\n'),
+    deps: {
+      root,
+      env: {},
+      out: (t) => out.push(t),
+      err: (t) => err.push(t),
+      readConfig: async () => config,
+    },
+  };
+};
+
+describe('engine list', () => {
+  test('reports the system default when empty', async () => {
+    const c = capture(makeTmpDir());
+    expect(await runEngine({ action: 'list' }, c.deps)).toBe(0);
+    expect(c.text()).toMatch(/system WebKit/i);
+  });
+
+  test('lists installed engines with their refcount, sorted by version', async () => {
+    const root = makeTmpDir();
+    await installFromDir(root, makeEngineDir(root, ID));
+    await installFromDir(root, makeEngineDir(root, ID2));
+    linkApp(root, '/opt/A', ID);
+    linkApp(root, '/opt/B', ID);
+    const c = capture(root);
+    await runEngine({ action: 'list' }, c.deps);
+    // ID2 (2.46) sorts before ID (2.52); ID has 2 apps.
+    expect(c.out[0]).toContain(ID2);
+    expect(c.out[1]).toContain(ID);
+    expect(c.out[1]).toContain('(2 apps)');
+  });
+});
+
+describe('engine which', () => {
+  test('system when the project does not pin', async () => {
+    const c = capture(makeTmpDir(), {});
+    await runEngine({ action: 'which' }, c.deps);
+    expect(c.text()).toMatch(/system/i);
+  });
+
+  test('flags a pinned-but-not-installed engine', async () => {
+    const c = capture(makeTmpDir(), { engine: { webkit: ID } });
+    await runEngine({ action: 'which' }, c.deps);
+    expect(c.text()).toContain(ID);
+    expect(c.text()).toMatch(/NOT installed/);
+  });
+
+  test('shows installed for a present engine', async () => {
+    const root = makeTmpDir();
+    await installFromDir(root, makeEngineDir(root, ID));
+    const c = capture(root, { engine: { webkit: ID } });
+    await runEngine({ action: 'which' }, c.deps);
+    expect(c.text()).toMatch(/\[installed\]/);
+  });
+});
+
+describe('engine install', () => {
+  test('installs from a local engine directory', async () => {
+    const root = makeTmpDir();
+    const src = makeEngineDir(root, ID);
+    const c = capture(root);
+    expect(await runEngine({ action: 'install', source: src }, c.deps)).toBe(0);
+    expect(c.text()).toContain(`installed ${ID}`);
+  });
+
+  test('errors (exit 1) on a non-directory source, honestly noting no remote feed', async () => {
+    const c = capture(makeTmpDir());
+    expect(await runEngine({ action: 'install', source: ID }, c.deps)).toBe(1);
+    expect(c.err.join('\n')).toMatch(/not available yet|local engine directory/i);
+  });
+});
+
+describe('engine use', () => {
+  test('prints a per-project snippet and never offers a global switch', async () => {
+    const c = capture(makeTmpDir());
+    expect(await runEngine({ action: 'use', id: ID }, c.deps)).toBe(0);
+    const text = c.text();
+    expect(text).toContain('per-project');
+    expect(text).toContain(ID);
+    expect(text).not.toMatch(/global switch is|--global/);
+  });
+
+  test('rejects a malformed id', async () => {
+    const c = capture(makeTmpDir());
+    expect(await runEngine({ action: 'use', id: 'nope' }, c.deps)).toBe(1);
+  });
+});
+
+describe('engine prune', () => {
+  test('dry-run reports but deletes nothing', async () => {
+    const root = makeTmpDir();
+    await installFromDir(root, makeEngineDir(root, ID));
+    const c = capture(root);
+    await runEngine({ action: 'prune', dryRun: true }, c.deps);
+    expect(c.text()).toMatch(/dry run/i);
+    expect(c.text()).toContain(ID);
+  });
+});
+
+describe('engine verify', () => {
+  test('ok for a healthy engine, fail for an absent one', async () => {
+    const root = makeTmpDir();
+    await installFromDir(root, makeEngineDir(root, ID));
+    const ok = capture(root);
+    expect(await runEngine({ action: 'verify', id: ID }, ok.deps)).toBe(0);
+    const bad = capture(root);
+    expect(await runEngine({ action: 'verify', id: ID2 }, bad.deps)).toBe(1);
+  });
+});
+
+describe('doctor', () => {
+  test('reports the runtime, store, and a clean system project (exit 0)', async () => {
+    const c = capture(makeTmpDir(), {});
+    expect(await runDoctor(undefined, c.deps)).toBe(0);
+    expect(c.text()).toMatch(/Bunmaska doctor/);
+    expect(c.text()).toMatch(/store:/);
+  });
+
+  test('exits 1 when the project pins an uninstalled engine', async () => {
+    const c = capture(makeTmpDir(), { engine: { webkit: ID } });
+    expect(await runDoctor('.', c.deps)).toBe(1);
+    expect(c.err.join('\n')).toContain(ID);
+  });
+});

--- a/tests/unit/cli/engine-store.test.ts
+++ b/tests/unit/cli/engine-store.test.ts
@@ -7,6 +7,7 @@ import {
   enginesPath,
   engineDir,
   gc,
+  installFromDir,
   installFromSource,
   type InstallSource,
   isInstalled,
@@ -16,6 +17,7 @@ import {
   markerPath,
   readLinks,
   unlinkApp,
+  verifyEngine,
   withLock,
 } from '../../../src/cli/engine-store';
 
@@ -170,6 +172,62 @@ describe('gc', () => {
     expect(result.droppedLinks).toBe(1);
     expect(result.removed).toEqual([ID]);
     expect(readLinks(root)).toEqual([]);
+  });
+});
+
+/** Build a valid, already-extracted engine source dir (lib/ + engine.json). */
+const makeEngineDir = (parent: string, id: string, soname = 'libwebkitgtk-6.0.so.4'): string => {
+  const { mkdirSync } = require('node:fs') as typeof import('node:fs');
+  const dir = join(parent, `src-${id}`);
+  mkdirSync(join(dir, 'lib'), { recursive: true });
+  writeFileSync(join(dir, 'lib', soname), 'SO');
+  writeFileSync(join(dir, 'engine.json'), JSON.stringify({ id, soname }));
+  return dir;
+};
+
+describe('installFromDir', () => {
+  test('copies a local engine tree in and marks it complete; idempotent', async () => {
+    const root = makeTmpDir();
+    const src = makeEngineDir(root, ID);
+    const first = await installFromDir(root, src);
+    expect(first).toEqual({ id: ID, installed: true });
+    expect(isInstalled(root, ID)).toBe(true);
+    expect(existsSync(join(engineDir(root, ID), 'lib', 'libwebkitgtk-6.0.so.4'))).toBe(true);
+
+    const second = await installFromDir(root, src);
+    expect(second).toEqual({ id: ID, installed: false });
+  });
+
+  test('rejects a source dir with no readable engine.json', async () => {
+    const root = makeTmpDir();
+    const { mkdirSync } = await import('node:fs');
+    const bogus = join(root, 'bogus');
+    mkdirSync(bogus, { recursive: true });
+    await expect(installFromDir(root, bogus)).rejects.toThrow(/engine\.json/i);
+  });
+});
+
+describe('verifyEngine', () => {
+  test('ok for a well-formed installed engine', async () => {
+    const root = makeTmpDir();
+    await installFromDir(root, makeEngineDir(root, ID));
+    expect(verifyEngine(root, ID)).toEqual({ id: ID, ok: true, problems: [] });
+  });
+
+  test('reports a missing soname lib', async () => {
+    const root = makeTmpDir();
+    await installFromDir(root, makeEngineDir(root, ID));
+    rmSync(join(engineDir(root, ID), 'lib', 'libwebkitgtk-6.0.so.4'), { force: true });
+    const result = verifyEngine(root, ID);
+    expect(result.ok).toBe(false);
+    expect(result.problems.join(' ')).toMatch(/missing lib/);
+  });
+
+  test('reports a not-installed engine', () => {
+    const root = makeTmpDir();
+    const result = verifyEngine(root, ID);
+    expect(result.ok).toBe(false);
+    expect(result.problems.length).toBeGreaterThan(0);
   });
 });
 

--- a/tests/unit/cli/engine-store.test.ts
+++ b/tests/unit/cli/engine-store.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { contentHash } from '../../../src/common/manifest';
+import {
+  enginesPath,
+  engineDir,
+  gc,
+  installFromSource,
+  type InstallSource,
+  isInstalled,
+  linkApp,
+  linkPath,
+  listInstalled,
+  markerPath,
+  readLinks,
+  unlinkApp,
+  withLock,
+} from '../../../src/cli/engine-store';
+
+const tmpDirs: string[] = [];
+const makeTmpDir = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'bunmaska-store-'));
+  tmpDirs.push(dir);
+  return dir;
+};
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const ID = 'webkitgtk-6.0-2.52.4-bunmaska1-linux-x64';
+const ID2 = 'webkitgtk-6.0-2.46.0-bunmaska1-linux-x64';
+
+/** A fake engine tarball payload + its honest manifest hash. */
+const fakeSource = (id: string, body = 'ENGINE-BYTES'): InstallSource => {
+  const bytes = new TextEncoder().encode(`${id}:${body}`);
+  return { id, bytes, expectedHash: contentHash(bytes) };
+};
+
+/** Extract that writes a deterministic engine tree from the tarball bytes. */
+const fakeExtract = async (bytes: Uint8Array, destDir: string): Promise<void> => {
+  const { mkdirSync } = await import('node:fs');
+  mkdirSync(join(destDir, 'lib'), { recursive: true });
+  writeFileSync(join(destDir, 'lib', 'libwebkitgtk-6.0.so.4'), bytes);
+  writeFileSync(join(destDir, 'engine.json'), JSON.stringify({ soname: 'libwebkitgtk-6.0.so.4' }));
+};
+
+describe('enginesPath (env-driven default root)', () => {
+  test('honors BUNMASKA_ENGINES_PATH first', () => {
+    expect(enginesPath({ BUNMASKA_ENGINES_PATH: '/custom/engines' })).toBe('/custom/engines');
+  });
+
+  test('falls back to <BUNMASKA_HOME>/webkit', () => {
+    expect(enginesPath({ BUNMASKA_HOME: '/srv/bm' })).toBe('/srv/bm/webkit');
+  });
+
+  test('defaults under the home dir when unset', () => {
+    const path = enginesPath({ HOME: '/home/alice' });
+    expect(path.endsWith('/.bunmaska/webkit')).toBe(true);
+  });
+});
+
+describe('path helpers', () => {
+  test('engineDir / markerPath compose under the root', () => {
+    expect(engineDir('/r', ID)).toBe(`/r/${ID}`);
+    expect(markerPath('/r', ID)).toBe(`/r/${ID}/INSTALLATION_COMPLETE`);
+  });
+
+  test('linkPath is a stable hash under .links', () => {
+    expect(linkPath('/r', '/opt/App')).toBe(linkPath('/r', '/opt/App'));
+    expect(linkPath('/r', '/opt/App')).not.toBe(linkPath('/r', '/opt/Other'));
+    expect(linkPath('/r', '/opt/App').startsWith('/r/.links/')).toBe(true);
+  });
+});
+
+describe('installFromSource', () => {
+  test('extracts, then writes the INSTALLATION_COMPLETE marker LAST', async () => {
+    const root = makeTmpDir();
+    const order: string[] = [];
+    await installFromSource(root, fakeSource(ID), {
+      extract: async (bytes, dest) => {
+        order.push('extract');
+        await fakeExtract(bytes, dest);
+      },
+      onMarker: () => order.push('marker'),
+    });
+    expect(order).toEqual(['extract', 'marker']);
+    expect(isInstalled(root, ID)).toBe(true);
+    expect(existsSync(join(engineDir(root, ID), 'lib', 'libwebkitgtk-6.0.so.4'))).toBe(true);
+  });
+
+  test('rejects a hash mismatch and leaves NO engine dir behind', async () => {
+    const root = makeTmpDir();
+    const bad: InstallSource = { ...fakeSource(ID), expectedHash: 'deadbeefdeadbeef' };
+    await expect(installFromSource(root, bad, { extract: fakeExtract })).rejects.toThrow(
+      /integrity|hash/i,
+    );
+    expect(existsSync(engineDir(root, ID))).toBe(false);
+  });
+
+  test('is idempotent — a second install does not re-extract', async () => {
+    const root = makeTmpDir();
+    let extracts = 0;
+    const deps = {
+      extract: async (b: Uint8Array, d: string) => {
+        extracts += 1;
+        await fakeExtract(b, d);
+      },
+    };
+    const first = await installFromSource(root, fakeSource(ID), deps);
+    const second = await installFromSource(root, fakeSource(ID), deps);
+    expect(first.installed).toBe(true);
+    expect(second.installed).toBe(false);
+    expect(extracts).toBe(1);
+  });
+});
+
+describe('listInstalled', () => {
+  test('returns only marker-complete engine dirs', async () => {
+    const root = makeTmpDir();
+    await installFromSource(root, fakeSource(ID), { extract: fakeExtract });
+    // A half-installed dir without the marker must be ignored.
+    const { mkdirSync } = await import('node:fs');
+    mkdirSync(engineDir(root, ID2), { recursive: true });
+    expect(listInstalled(root)).toEqual([ID]);
+  });
+});
+
+describe('links (refcount source of truth)', () => {
+  test('linkApp / readLinks / unlinkApp round-trip', () => {
+    const root = makeTmpDir();
+    linkApp(root, '/opt/MyApp', ID);
+    linkApp(root, '/opt/OtherApp', ID2);
+    const links = readLinks(root).sort((a, b) => a.app.localeCompare(b.app));
+    expect(links).toEqual([
+      { app: '/opt/MyApp', engine: ID },
+      { app: '/opt/OtherApp', engine: ID2 },
+    ]);
+    unlinkApp(root, '/opt/MyApp');
+    expect(readLinks(root)).toEqual([{ app: '/opt/OtherApp', engine: ID2 }]);
+  });
+});
+
+describe('gc', () => {
+  test('keeps referenced engines, removes the rest, honors dry-run', async () => {
+    const root = makeTmpDir();
+    await installFromSource(root, fakeSource(ID), { extract: fakeExtract });
+    await installFromSource(root, fakeSource(ID2), { extract: fakeExtract });
+    linkApp(root, '/opt/MyApp', ID); // only ID is referenced
+
+    const dry = await gc(root, { exists: () => true, dryRun: true });
+    expect(dry.removed).toEqual([ID2]);
+    expect(isInstalled(root, ID2)).toBe(true); // dry-run deletes nothing
+
+    const real = await gc(root, { exists: () => true });
+    expect(real.kept).toEqual([ID]);
+    expect(real.removed).toEqual([ID2]);
+    expect(isInstalled(root, ID)).toBe(true);
+    expect(isInstalled(root, ID2)).toBe(false);
+  });
+
+  test('drops links whose app no longer exists, freeing its engine', async () => {
+    const root = makeTmpDir();
+    await installFromSource(root, fakeSource(ID), { extract: fakeExtract });
+    linkApp(root, '/opt/GoneApp', ID);
+    const result = await gc(root, { exists: (p) => p !== '/opt/GoneApp' });
+    expect(result.droppedLinks).toBe(1);
+    expect(result.removed).toEqual([ID]);
+    expect(readLinks(root)).toEqual([]);
+  });
+});
+
+describe('withLock', () => {
+  test('runs the body and releases the lock', async () => {
+    const root = makeTmpDir();
+    const value = await withLock(root, async () => 42);
+    expect(value).toBe(42);
+    expect(existsSync(join(root, '__dirlock'))).toBe(false);
+  });
+
+  test('releases the lock even when the body throws', async () => {
+    const root = makeTmpDir();
+    await expect(
+      withLock(root, async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+    expect(existsSync(join(root, '__dirlock'))).toBe(false);
+  });
+
+  test('serializes concurrent critical sections', async () => {
+    const root = makeTmpDir();
+    const trace: string[] = [];
+    const crit = (tag: string) =>
+      withLock(root, async () => {
+        trace.push(`${tag}:enter`);
+        await Bun.sleep(5);
+        trace.push(`${tag}:exit`);
+      });
+    await Promise.all([crit('a'), crit('b')]);
+    // Whichever ran first must fully finish before the other enters.
+    expect(trace).toContain('a:enter');
+    expect(trace).toContain('b:enter');
+    const firstExit = trace.indexOf(`${trace[0]?.split(':')[0]}:exit`);
+    const otherEnter = trace.findIndex(
+      (t) => t.endsWith(':enter') && !t.startsWith(trace[0]?.split(':')[0] ?? ''),
+    );
+    expect(firstExit).toBeLessThan(otherEnter);
+  });
+});

--- a/tests/unit/cli/parse-args-engine.test.ts
+++ b/tests/unit/cli/parse-args-engine.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test';
+import { parseArgs } from '../../../src/cli/parse-args';
+
+const ID = 'webkitgtk-6.0-2.52.4-bunmaska1-linux-x64';
+
+describe('parseArgs — engine subcommands', () => {
+  test('engine list', () => {
+    expect(parseArgs(['engine', 'list'])).toEqual({ kind: 'engine', sub: { action: 'list' } });
+  });
+
+  test('engine which (no target)', () => {
+    expect(parseArgs(['engine', 'which'])).toEqual({ kind: 'engine', sub: { action: 'which' } });
+  });
+
+  test('engine which <target>', () => {
+    expect(parseArgs(['engine', 'which', '.'])).toEqual({
+      kind: 'engine',
+      sub: { action: 'which', target: '.' },
+    });
+  });
+
+  test('engine install <source>', () => {
+    expect(parseArgs(['engine', 'install', './my-engine'])).toEqual({
+      kind: 'engine',
+      sub: { action: 'install', source: './my-engine' },
+    });
+  });
+
+  test('engine install requires a source', () => {
+    expect(parseArgs(['engine', 'install'])).toMatchObject({ kind: 'error' });
+  });
+
+  test('engine use <id>', () => {
+    expect(parseArgs(['engine', 'use', ID])).toEqual({
+      kind: 'engine',
+      sub: { action: 'use', id: ID },
+    });
+  });
+
+  test('engine use <id> --for <dir>', () => {
+    expect(parseArgs(['engine', 'use', ID, '--for', 'apps/demo'])).toEqual({
+      kind: 'engine',
+      sub: { action: 'use', id: ID, for: 'apps/demo' },
+    });
+  });
+
+  test('engine use rejects a --global switch (anti-nvm guardrail)', () => {
+    expect(parseArgs(['engine', 'use', ID, '--global'])).toMatchObject({ kind: 'error' });
+  });
+
+  test('engine prune and engine prune --dry-run', () => {
+    expect(parseArgs(['engine', 'prune'])).toEqual({
+      kind: 'engine',
+      sub: { action: 'prune', dryRun: false },
+    });
+    expect(parseArgs(['engine', 'prune', '--dry-run'])).toEqual({
+      kind: 'engine',
+      sub: { action: 'prune', dryRun: true },
+    });
+  });
+
+  test('engine verify <id>', () => {
+    expect(parseArgs(['engine', 'verify', ID])).toEqual({
+      kind: 'engine',
+      sub: { action: 'verify', id: ID },
+    });
+  });
+
+  test('engine with no subcommand is an error', () => {
+    expect(parseArgs(['engine'])).toMatchObject({ kind: 'error' });
+  });
+
+  test('engine with an unknown subcommand is an error', () => {
+    expect(parseArgs(['engine', 'frobnicate'])).toMatchObject({ kind: 'error' });
+  });
+});
+
+describe('parseArgs — doctor', () => {
+  test('doctor (no target)', () => {
+    expect(parseArgs(['doctor'])).toEqual({ kind: 'doctor' });
+  });
+
+  test('doctor <target>', () => {
+    expect(parseArgs(['doctor', '.'])).toEqual({ kind: 'doctor', target: '.' });
+  });
+});

--- a/tests/unit/cli/parse-args-engine.test.ts
+++ b/tests/unit/cli/parse-args-engine.test.ts
@@ -48,14 +48,18 @@ describe('parseArgs — engine subcommands', () => {
     expect(parseArgs(['engine', 'use', ID, '--global'])).toMatchObject({ kind: 'error' });
   });
 
-  test('engine prune and engine prune --dry-run', () => {
+  test('engine prune, --dry-run, and --force', () => {
     expect(parseArgs(['engine', 'prune'])).toEqual({
       kind: 'engine',
-      sub: { action: 'prune', dryRun: false },
+      sub: { action: 'prune', dryRun: false, force: false },
     });
     expect(parseArgs(['engine', 'prune', '--dry-run'])).toEqual({
       kind: 'engine',
-      sub: { action: 'prune', dryRun: true },
+      sub: { action: 'prune', dryRun: true, force: false },
+    });
+    expect(parseArgs(['engine', 'prune', '--force'])).toEqual({
+      kind: 'engine',
+      sub: { action: 'prune', dryRun: false, force: true },
     });
   });
 

--- a/tests/unit/common/config-schema.test.ts
+++ b/tests/unit/common/config-schema.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test';
+import { defineConfig, validateConfig } from '../../../src/common/config-schema';
+import { InvalidArgumentError } from '../../../src/common/errors';
+
+describe('validateConfig — engine field', () => {
+  test('omits engine when absent (default = system behaviour, no key)', () => {
+    expect(validateConfig({ name: 'A' })).toEqual({ name: 'A' });
+  });
+
+  test('accepts engine.webkit as a full id', () => {
+    const id = 'webkitgtk-6.0-2.52.4-bunmaska1-linux-x64';
+    expect(validateConfig({ engine: { webkit: id } })).toEqual({ engine: { webkit: id } });
+  });
+
+  test("accepts engine.webkit = 'system' and a bare upstream version", () => {
+    expect(validateConfig({ engine: { webkit: 'system' } })).toEqual({
+      engine: { webkit: 'system' },
+    });
+    expect(validateConfig({ engine: { webkit: '2.52.4' } })).toEqual({
+      engine: { webkit: '2.52.4' },
+    });
+  });
+
+  test('accepts engine.embed boolean', () => {
+    expect(validateConfig({ engine: { embed: true } })).toEqual({ engine: { embed: true } });
+  });
+
+  test('drops an empty engine object to an empty object', () => {
+    expect(validateConfig({ engine: {} })).toEqual({ engine: {} });
+  });
+
+  test('rejects a non-object engine', () => {
+    expect(() => validateConfig({ engine: 'system' })).toThrow(InvalidArgumentError);
+  });
+
+  test('rejects a non-string engine.webkit', () => {
+    expect(() => validateConfig({ engine: { webkit: 6 } })).toThrow(InvalidArgumentError);
+  });
+
+  test('rejects a non-boolean engine.embed', () => {
+    expect(() => validateConfig({ engine: { embed: 'yes' } })).toThrow(InvalidArgumentError);
+  });
+
+  test('defineConfig passes an engine config through untouched', () => {
+    const cfg = defineConfig({ engine: { webkit: '2.52.4', embed: false } });
+    expect(cfg.engine).toEqual({ webkit: '2.52.4', embed: false });
+  });
+});

--- a/tests/unit/common/engine-id.test.ts
+++ b/tests/unit/common/engine-id.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'bun:test';
+import { BunmaskaError } from '../../../src/common/errors';
+import {
+  compareEngineIds,
+  type EngineRef,
+  formatEngineId,
+  isSystemEngine,
+  parseEngineId,
+  SYSTEM_ENGINE,
+} from '../../../src/common/engine-id';
+
+const ref: EngineRef = {
+  engine: 'webkitgtk',
+  api: '6.0',
+  upstream: '2.52.4',
+  rev: 'bunmaska1',
+  os: 'linux',
+  arch: 'x64',
+};
+
+describe('formatEngineId', () => {
+  test('joins the six fields with dashes', () => {
+    expect(formatEngineId(ref)).toBe('webkitgtk-6.0-2.52.4-bunmaska1-linux-x64');
+  });
+
+  test('rejects a field containing a dash (would break round-trip)', () => {
+    expect(() => formatEngineId({ ...ref, rev: 'bun-maska1' })).toThrow(BunmaskaError);
+    expect(() => formatEngineId({ ...ref, upstream: '2.52-4' })).toThrow(BunmaskaError);
+  });
+});
+
+describe('parseEngineId', () => {
+  test('round-trips a formatted id', () => {
+    expect(parseEngineId(formatEngineId(ref))).toEqual(ref);
+  });
+
+  test('reads each field back in order', () => {
+    const parsed = parseEngineId('webkitgtk-6.0-2.46.0-bunmaska2-linux-arm64');
+    expect(parsed).toEqual({
+      engine: 'webkitgtk',
+      api: '6.0',
+      upstream: '2.46.0',
+      rev: 'bunmaska2',
+      os: 'linux',
+      arch: 'arm64',
+    });
+  });
+
+  test('accepts the reserved windows/webview2 namespace', () => {
+    const parsed = parseEngineId('webview2-fixed-126.0.2592-bunmaska1-windows-x64');
+    expect(parsed.engine).toBe('webview2');
+    expect(parsed.os).toBe('windows');
+  });
+
+  test.each([
+    ['too few fields', 'webkitgtk-6.0-2.52.4-linux-x64'],
+    ['too many fields', 'webkitgtk-6.0-2.52.4-bunmaska1-extra-linux-x64'],
+    ['unknown engine family', 'chromium-6.0-2.52.4-bunmaska1-linux-x64'],
+    ['unknown os', 'webkitgtk-6.0-2.52.4-bunmaska1-freebsd-x64'],
+    ['unknown arch', 'webkitgtk-6.0-2.52.4-bunmaska1-linux-riscv'],
+    ['non-numeric upstream', 'webkitgtk-6.0-latest-bunmaska1-linux-x64'],
+    ['empty', ''],
+    ['the system sentinel is not a parseable id', SYSTEM_ENGINE],
+  ])('rejects %s', (_label, id) => {
+    expect(() => parseEngineId(id)).toThrow(BunmaskaError);
+  });
+});
+
+describe('isSystemEngine', () => {
+  test('true for the sentinel and case-insensitively', () => {
+    expect(isSystemEngine(SYSTEM_ENGINE)).toBe(true);
+    expect(isSystemEngine('System')).toBe(true);
+  });
+
+  test('false for a real engine id', () => {
+    expect(isSystemEngine('webkitgtk-6.0-2.52.4-bunmaska1-linux-x64')).toBe(false);
+  });
+});
+
+describe('compareEngineIds', () => {
+  const a = 'webkitgtk-6.0-2.46.0-bunmaska1-linux-x64';
+  const b = 'webkitgtk-6.0-2.52.4-bunmaska1-linux-x64';
+
+  test('orders by upstream version', () => {
+    expect(compareEngineIds(a, b)).toBe(-1);
+    expect(compareEngineIds(b, a)).toBe(1);
+    expect(compareEngineIds(a, a)).toBe(0);
+  });
+
+  test('tie-breaks equal upstream by build revision', () => {
+    const r1 = 'webkitgtk-6.0-2.52.4-bunmaska1-linux-x64';
+    const r2 = 'webkitgtk-6.0-2.52.4-bunmaska2-linux-x64';
+    expect(compareEngineIds(r1, r2)).toBe(-1);
+  });
+
+  test('sorts a list ascending', () => {
+    const sorted = [b, a].sort(compareEngineIds);
+    expect(sorted).toEqual([a, b]);
+  });
+});

--- a/tests/unit/main/engine-resolve.test.ts
+++ b/tests/unit/main/engine-resolve.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  bakedIdCandidates,
   engineEnv,
   engineLibPath,
   type ResolveDeps,
@@ -56,6 +57,20 @@ describe('resolveEngineWith', () => {
     const r = resolve({ env: { BUNMASKA_WEBKIT_ID: 'not-an-engine-id' } });
     expect(r.mode).toBe('system');
     expect(r.warnings.length).toBe(1);
+  });
+});
+
+describe('bakedIdCandidates', () => {
+  test('prefers the install layout usr/share/<slug>/engine.id', () => {
+    const c = bakedIdCandidates('/opt/app/usr/bin/my-app', {});
+    expect(c[0]).toBe('/opt/app/usr/share/my-app/engine.id');
+    expect(c[1]).toBe('/opt/app/usr/bin/engine.id');
+  });
+
+  test('an explicit BUNMASKA_ENGINE_ID_FILE wins outright', () => {
+    expect(
+      bakedIdCandidates('/opt/app/usr/bin/my-app', { BUNMASKA_ENGINE_ID_FILE: '/x/id' }),
+    ).toEqual(['/x/id']);
   });
 });
 

--- a/tests/unit/main/engine-resolve.test.ts
+++ b/tests/unit/main/engine-resolve.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
   bakedIdCandidates,
   type EngineResolution,
@@ -113,6 +113,9 @@ describe('engineEnv', () => {
 });
 
 describe('prepareEngineForLoad', () => {
+  // Reset BEFORE each test too: on Linux the real GTK/WebKitGTK loaders run in
+  // the same process and set this one-shot guard, which would otherwise leak in.
+  beforeEach(() => resetEnginePreparation());
   afterEach(() => resetEnginePreparation());
 
   test('pinned: exports the engine env and prints warnings, exactly once', () => {

--- a/tests/unit/main/engine-resolve.test.ts
+++ b/tests/unit/main/engine-resolve.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  engineEnv,
+  engineLibPath,
+  type ResolveDeps,
+  resolveEngineWith,
+} from '../../../src/main/engine/resolve';
+
+const ID = 'webkitgtk-6.0-2.52.4-bunmaska1-linux-x64';
+const ROOT = '/store/webkit';
+
+const resolve = (deps: ResolveDeps) =>
+  resolveEngineWith({ enginesRoot: ROOT, exists: () => true, readBakedId: () => null, ...deps });
+
+describe('resolveEngineWith', () => {
+  test('BUNMASKA_WEBKIT_PATH wins — explicit pinned dir, highest precedence', () => {
+    const r = resolve({ env: { BUNMASKA_WEBKIT_PATH: '/opt/webkit/lib' } });
+    expect(r.mode).toBe('pinned');
+    expect(r.libDir).toBe('/opt/webkit/lib');
+    expect(r.warnings).toEqual([]);
+  });
+
+  test('no id anywhere -> system (the default, no warning)', () => {
+    const r = resolve({ env: {}, readBakedId: () => null });
+    expect(r.mode).toBe('system');
+    expect(r.warnings).toEqual([]);
+  });
+
+  test("the 'system' sentinel -> system", () => {
+    const r = resolve({ env: { BUNMASKA_WEBKIT_ID: 'system' } });
+    expect(r.mode).toBe('system');
+  });
+
+  test('baked id with a present marker -> pinned at <root>/<id>/lib', () => {
+    const r = resolve({ env: {}, readBakedId: () => ID, exists: () => true });
+    expect(r.mode).toBe('pinned');
+    expect(r.libDir).toBe(`${ROOT}/${ID}/lib`);
+    expect(r.warnings).toEqual([]);
+  });
+
+  test('baked id but missing marker -> system fallback, loud warning names the id', () => {
+    const r = resolve({ env: {}, readBakedId: () => ID, exists: () => false });
+    expect(r.mode).toBe('system');
+    expect(r.warnings.length).toBe(1);
+    expect(r.warnings[0]).toContain(ID);
+    expect(r.warnings[0]).toMatch(/tested|system|install/i);
+  });
+
+  test('BUNMASKA_WEBKIT_ID overrides the baked id', () => {
+    const other = 'webkitgtk-6.0-2.46.0-bunmaska1-linux-x64';
+    const r = resolve({ env: { BUNMASKA_WEBKIT_ID: other }, readBakedId: () => ID });
+    expect(r.libDir).toBe(`${ROOT}/${other}/lib`);
+  });
+
+  test('a malformed id -> system fallback with a warning', () => {
+    const r = resolve({ env: { BUNMASKA_WEBKIT_ID: 'not-an-engine-id' } });
+    expect(r.mode).toBe('system');
+    expect(r.warnings.length).toBe(1);
+  });
+});
+
+describe('engineLibPath', () => {
+  test('pinned -> absolute path into the engine lib dir', () => {
+    const r = resolve({ env: {}, readBakedId: () => ID });
+    expect(engineLibPath(r, 'libwebkitgtk-6.0.so.4')).toBe(
+      `${ROOT}/${ID}/lib/libwebkitgtk-6.0.so.4`,
+    );
+    expect(engineLibPath(r, 'libgtk-4.so.1')).toBe(`${ROOT}/${ID}/lib/libgtk-4.so.1`);
+  });
+
+  test('system -> the bare soname (ld.so default search)', () => {
+    const r = resolve({ env: {} });
+    expect(engineLibPath(r, 'libwebkitgtk-6.0.so.4')).toBe('libwebkitgtk-6.0.so.4');
+  });
+});
+
+describe('engineEnv', () => {
+  test('pinned -> prepends the lib dir to LD_LIBRARY_PATH and sets GIO_EXTRA_MODULES', () => {
+    const r = resolve({ env: {}, readBakedId: () => ID });
+    const env = engineEnv(r, { LD_LIBRARY_PATH: '/usr/lib' });
+    expect(env.LD_LIBRARY_PATH).toBe(`${ROOT}/${ID}/lib:/usr/lib`);
+    expect(env.GIO_EXTRA_MODULES).toBe(`${ROOT}/${ID}/lib/gio/modules`);
+  });
+
+  test('pinned with no prior LD_LIBRARY_PATH -> just the lib dir', () => {
+    const r = resolve({ env: {}, readBakedId: () => ID });
+    const env = engineEnv(r, {});
+    expect(env.LD_LIBRARY_PATH).toBe(`${ROOT}/${ID}/lib`);
+  });
+
+  test('system -> no env changes', () => {
+    const r = resolve({ env: {} });
+    expect(engineEnv(r, { LD_LIBRARY_PATH: '/usr/lib' })).toEqual({});
+  });
+});

--- a/tests/unit/main/engine-resolve.test.ts
+++ b/tests/unit/main/engine-resolve.test.ts
@@ -1,9 +1,12 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 import {
   bakedIdCandidates,
+  type EngineResolution,
   engineEnv,
   engineLibPath,
+  prepareEngineForLoad,
   type ResolveDeps,
+  resetEnginePreparation,
   resolveEngineWith,
 } from '../../../src/main/engine/resolve';
 
@@ -106,5 +109,36 @@ describe('engineEnv', () => {
   test('system -> no env changes', () => {
     const r = resolve({ env: {} });
     expect(engineEnv(r, { LD_LIBRARY_PATH: '/usr/lib' })).toEqual({});
+  });
+});
+
+describe('prepareEngineForLoad', () => {
+  afterEach(() => resetEnginePreparation());
+
+  test('pinned: exports the engine env and prints warnings, exactly once', () => {
+    const pinned: EngineResolution = {
+      mode: 'pinned',
+      libDir: '/store/x/lib',
+      warnings: ['heads up'],
+    };
+    const target: Record<string, string | undefined> = { LD_LIBRARY_PATH: '/usr/lib' };
+    const writes: string[] = [];
+    prepareEngineForLoad(pinned, target, (s) => writes.push(s));
+    expect(target['LD_LIBRARY_PATH']).toBe('/store/x/lib:/usr/lib');
+    expect(target['GIO_EXTRA_MODULES']).toBe('/store/x/lib/gio/modules');
+    expect(writes).toEqual(['heads up\n']);
+
+    // A second call (e.g. the other loader) is a no-op — single shared engine.
+    prepareEngineForLoad(pinned, { LD_LIBRARY_PATH: '/other' }, (s) => writes.push(s));
+    expect(writes).toEqual(['heads up\n']);
+  });
+
+  test('system: applies no env and prints nothing', () => {
+    const target: Record<string, string | undefined> = { LD_LIBRARY_PATH: '/usr/lib' };
+    const writes: string[] = [];
+    prepareEngineForLoad({ mode: 'system', warnings: [] }, target, (s) => writes.push(s));
+    expect(target['LD_LIBRARY_PATH']).toBe('/usr/lib');
+    expect(target['GIO_EXTRA_MODULES']).toBeUndefined();
+    expect(writes).toEqual([]);
   });
 });


### PR DESCRIPTION
## What

The "tested == shipped" engine layer, built on Playwright's browser-registry model (not nvm): **different apps pin different WebKit versions, installed side by side, each resolving its own at launch — no global switch.**

- **engine-id** (`src/common/engine-id.ts`): a flat, content-addressed `webkitgtk-6.0-2.52.4-bunmaska1-linux-x64` id; the per-app pin and the store dir name.
- **engine store** (`src/cli/engine-store.ts`): `~/.bunmaska/webkit/<id>/` with `INSTALLATION_COMPLETE` marker, content-hash integrity, `.links` refcount, GC, and a cross-process lock.
- **launch resolution** (`src/main/engine/resolve.ts`): env override → baked `engine.id` → marker check → **loud system fallback** (the app still launches, but flags that tested==shipped is broken).
- **loader hook**: the two Linux loaders (`webkitgtk-ffi.ts`, `gtk-ffi.ts`) share one resolution before `dlopen` (so GTK + WebKit come from the same engine).
- **CLI**: `bunmaska engine list|which|install|use|prune|verify` + `bunmaska doctor`. `use` is per-project only (no `--global`).
- **`.deb` fix**: the generated package now declares `Depends: libwebkitgtk-6.0-4, libgtk-4-1` (latent crash-on-bare-box bug) and bakes the app's `engine.id`.

Bumps to `0.1.0-alpha.1`. Full design in `.admin/ENGINE-STORE-PLAN.md`.

## Honest scope

The whole resolution/store/CLI/loader-wiring layer ships and is tested against fixtures (macOS + Ubuntu CI). **Out of scope (follow-ups):** building/hosting real signed WebKitGTK engine artifacts, the actual `dlopen`-from-store on a real Linux box, macOS `WebKit.framework` pinning, and Windows WebView2 — the design reserves the id namespace + resolver shape for all three.

## Tests

1382 pass / 0 fail locally (`bun run validate`). New: engine-id, config engine field, store (install/marker/refcount/GC/lock/verify), resolution decision table, CLI + doctor, `.deb` Depends + bake, prune-safety guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)