### PR TITLE
chore: npm publish-prep (os win32, alpha.3) + doc honesty fixes

### DIFF
--- a/apps/web/src/content/docs/building.md
+++ b/apps/web/src/content/docs/building.md
@@ -61,7 +61,7 @@ Build on the target architecture: an `x64` box produces `x64`, an **ARM64** box 
 
 ## Windows
 
-Not available yet - see [Platform Support](/docs/platforms) and the [roadmap](/roadmap). When WinCairo support lands, `bunmaska build` will gain Windows targets.
+`bunmaska build --target windows` compiles a self-contained `.exe` and packages it as a `.zip` (x64). Because Windows ships no system WebKit, the app needs a **WinCairo `WebKit2.dll`** - today you build that from WebKit source and embed it (`--embed-engine`, or point `BUNMASKA_WEBKIT_PATH` at a build). A hosted prebuilt engine - so you don't have to build it yourself - is the next step. See [Platform Support](/docs/platforms) and the [roadmap](/roadmap).
 
 ## Auto-updates
 

--- a/apps/web/src/pages/roadmap.astro
+++ b/apps/web/src/pages/roadmap.astro
@@ -64,7 +64,7 @@ const phases: { status: Status; title: string; note?: string; items: string[] }[
 ];
 ---
 
-<Base title="Roadmap" description="What Bunmaska is building, where it is today, and the honest plan - including Windows (WinCairo on ARM64 + x64, never WebView2).">
+<Base title="Roadmap" description="What Bunmaska is building, where it is today, and the honest plan - including Windows (WinCairo WebKit, x64 today and ARM64 next, never WebView2).">
   <Nav />
 
   <main>
@@ -178,8 +178,8 @@ const phases: { status: Status; title: string; note?: string; items: string[] }[
               },
               {
                 icon: "lucide:cpu",
-                t: "ARM64 + x64. Never 32-bit.",
-                d: "Windows is moving to ARM (Snapdragon X, Copilot+ PCs, NVIDIA's 2026 laptops). ARM64 + x64 covers the present and the future; x86 is not on the list.",
+                t: "x64 today, ARM64 next. Never 32-bit.",
+                d: "x64 ships now; ARM64 is on the roadmap (upstream WinCairo is x64-only for the moment). Windows is moving to ARM - Snapdragon X, Copilot+ PCs, NVIDIA's 2026 laptops - so ARM64 is a when, not an if. x86 isn't on the list at all.",
               },
               {
                 icon: "lucide:package",

--- a/packages/bunmaska/package.json
+++ b/packages/bunmaska/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunmaska",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "A drop-in replacement for Electron, built on Bun and system WebKit.",
   "keywords": [
     "electron",
@@ -9,6 +9,9 @@
     "webkit",
     "wkwebview",
     "webkitgtk",
+    "wincairo",
+    "windows",
+    "win32",
     "desktop",
     "gui",
     "ffi",
@@ -17,7 +20,7 @@
   ],
   "license": "MIT",
   "author": "Indrajeet O.",
-  "homepage": "https://github.com/ipfizz/bunmaska",
+  "homepage": "https://bunmaska.org",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ipfizz/bunmaska.git"
@@ -63,7 +66,8 @@
   },
   "os": [
     "darwin",
-    "linux"
+    "linux",
+    "win32"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Makes `bunmaska` publish-ready and closes the package/site honesty gaps the readiness audit flagged.

- **`os` now includes `win32`** - without this, `npm i bunmaska` hits `EBADPLATFORM` on Windows while the site says "Windows ships." (the hard blocker)
- **Bump to `0.1.0-alpha.3`** so the registry's first artifact is Windows-correct; **homepage → bunmaska.org**; **+windows/win32/wincairo keywords**.
- **Fixed the live ARM64 contradiction** on the roadmap (meta + a card said "ARM64 + x64" while the body says x64-only) → "x64 today, ARM64 next."
- **Fixed the stale `building.md`** ("Windows not available yet") → the real `--target windows` + WinCairo-engine story.

Left intentionally as-is: `files`/`exports`/`.ts`-source/`engines.bun` (correct for a Bun-only ESM package); **no `sideEffects:false`** (would break `app.whenReady()`'s bootstrap import). Validate green (1589 tests); site builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)