### PR TITLE
Make macOS packaged apps actually work (interactive + assets + entitlements)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunmaska",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "description": "A drop-in replacement for Electron, built on Bun and system WebKit.",
   "keywords": [
     "electron",

--- a/src/cli/app-assets.ts
+++ b/src/cli/app-assets.ts
@@ -1,0 +1,41 @@
+import { cpSync, existsSync, readdirSync } from 'node:fs';
+import { dirname, extname, join, resolve, sep } from 'node:path';
+
+const COMPILED_SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.mts', '.cts']);
+
+/**
+ * Whether a sibling of the entry ships as a runtime asset rather than being
+ * compiled into the binary. TypeScript sources, dotfiles and `node_modules` are
+ * excluded; HTML, JS preloads, CSS, images, JSON and the like are kept.
+ */
+export const isRuntimeAsset = (name: string): boolean =>
+  name !== 'node_modules' &&
+  !name.startsWith('.') &&
+  !COMPILED_SOURCE_EXTENSIONS.has(extname(name).toLowerCase());
+
+/**
+ * Copy the entry's sibling runtime assets into `destination` — the directory of
+ * the compiled executable — so the app resolves them next to itself at launch.
+ * The build output is skipped, so a destination nested under the entry's
+ * directory is never copied into itself. Returns the names copied.
+ */
+export const copyAppAssets = (entry: string, destination: string): string[] => {
+  const source = dirname(entry);
+  if (!existsSync(source)) {
+    return [];
+  }
+  const resolvedDestination = resolve(destination);
+  const copied: string[] = [];
+  for (const name of readdirSync(source)) {
+    if (!isRuntimeAsset(name)) {
+      continue;
+    }
+    const from = resolve(source, name);
+    if (resolvedDestination === from || resolvedDestination.startsWith(`${from}${sep}`)) {
+      continue;
+    }
+    cpSync(from, join(destination, name), { recursive: true });
+    copied.push(name);
+  }
+  return copied;
+};

--- a/src/cli/build-linux.ts
+++ b/src/cli/build-linux.ts
@@ -14,6 +14,7 @@ import { chmodSync, copyFileSync, existsSync, mkdirSync, writeFileSync } from 'n
 import { dirname, join, posix } from 'node:path';
 import { isSystemEngine, parseEngineId } from '../common/engine-id';
 import { BUNMASKA_VERSION } from '../common/version';
+import { copyAppAssets } from './app-assets';
 import { bundleIdSlug } from './build-macos';
 
 export type LinuxLayout = {
@@ -223,6 +224,9 @@ export const buildLinuxApp = async (opts: BuildLinuxAppOptions): Promise<BuildLi
 
   await compileLinuxBinary(opts.entry, layout.binPath);
   chmodSync(layout.binPath, 0o755);
+
+  // Ship the entry's runtime assets (the page, the preload) beside the binary.
+  copyAppAssets(opts.entry, dirname(layout.binPath));
 
   writeFileSync(
     layout.desktopPath,

--- a/src/cli/build-macos.ts
+++ b/src/cli/build-macos.ts
@@ -20,6 +20,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join, posix } from 'node:path';
 import { BUNMASKA_VERSION } from '../common/version';
+import { copyAppAssets } from './app-assets';
 
 /** Minimum macOS the bundle declares it supports. */
 const MINIMUM_SYSTEM_VERSION = '11.0';
@@ -124,19 +125,46 @@ export const appBundleLayout = (out: string, name: string): AppBundleLayout => {
 };
 
 /**
+ * Entitlements a Bun-compiled app needs under the Hardened Runtime: JIT and
+ * unsigned executable memory for JavaScriptCore and bun:ffi, and library
+ * validation disabled so the app can dlopen the system WebKit/AppKit at launch.
+ * Without these a hardened-runtime app traps (SIGTRAP) on its first FFI call.
+ */
+export const codesignEntitlements = (): string =>
+  `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>
+`;
+
+/**
  * Build the `codesign` argv that signs an `.app` bundle in place. Pure.
  *
  * Uses `--force --deep` so an existing signature is replaced and nested code is
- * signed, and `--options runtime` to opt the bundle into the macOS Hardened
- * Runtime (required for notarization). `identity` is passed verbatim after
- * `--sign`: a real `Developer ID Application: …` identity (which must be present
- * in the keychain) or `-` for an ad-hoc signature that needs no certificate.
+ * signed, `--options runtime` to opt into the macOS Hardened Runtime (required
+ * for notarization), and `--entitlements` to grant the JIT/FFI exceptions Bun
+ * needs. `identity` is passed verbatim after `--sign`: a real `Developer ID
+ * Application: …` identity, or `-` for an ad-hoc signature.
  */
-export const buildCodesignArgs = (identity: string, appPath: string): string[] => [
+export const buildCodesignArgs = (
+  identity: string,
+  appPath: string,
+  entitlementsPath: string,
+): string[] => [
   '--force',
   '--deep',
   '--options',
   'runtime',
+  '--entitlements',
+  entitlementsPath,
   '--sign',
   identity,
   appPath,
@@ -324,24 +352,35 @@ export type BuildDmg = (opts: BuildDmgOptions) => Promise<void>;
  * with the tool's stderr on a non-zero exit from either step.
  */
 export const codesignApp = async (identity: string, appPath: string): Promise<void> => {
-  const sign = Bun.spawn(['codesign', ...buildCodesignArgs(identity, appPath)], {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
-  const signExit = await sign.exited;
-  if (signExit !== 0) {
-    const stderr = await new Response(sign.stderr).text();
-    throw new Error(`codesign failed (exit ${signExit}):\n${stderr}`);
-  }
+  const entitlementsDir = mkdtempSync(join(tmpdir(), 'bunmaska-entitlements-'));
+  const entitlementsPath = join(entitlementsDir, 'app.entitlements');
+  writeFileSync(entitlementsPath, codesignEntitlements());
 
-  const verify = Bun.spawn(['codesign', ...buildCodesignVerifyArgs(appPath)], {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
-  const verifyExit = await verify.exited;
-  if (verifyExit !== 0) {
-    const stderr = await new Response(verify.stderr).text();
-    throw new Error(`codesign --verify failed (exit ${verifyExit}):\n${stderr}`);
+  try {
+    const sign = Bun.spawn(
+      ['codesign', ...buildCodesignArgs(identity, appPath, entitlementsPath)],
+      {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    );
+    const signExit = await sign.exited;
+    if (signExit !== 0) {
+      const stderr = await new Response(sign.stderr).text();
+      throw new Error(`codesign failed (exit ${signExit}):\n${stderr}`);
+    }
+
+    const verify = Bun.spawn(['codesign', ...buildCodesignVerifyArgs(appPath)], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const verifyExit = await verify.exited;
+    if (verifyExit !== 0) {
+      const stderr = await new Response(verify.stderr).text();
+      throw new Error(`codesign --verify failed (exit ${verifyExit}):\n${stderr}`);
+    }
+  } finally {
+    rmSync(entitlementsDir, { recursive: true, force: true });
   }
 };
 
@@ -396,6 +435,9 @@ export const buildMacApp = async (opts: BuildMacAppOptions): Promise<string> => 
   // Compile straight into the bundle's executable slot.
   await compileBinary(opts.entry, layout.executablePath);
   chmodSync(layout.executablePath, 0o755);
+
+  // Ship the entry's runtime assets (the page, the preload) beside the binary.
+  copyAppAssets(opts.entry, layout.macosDir);
 
   let iconFile: string | undefined;
   if (opts.icon !== undefined) {

--- a/src/cli/build-windows.ts
+++ b/src/cli/build-windows.ts
@@ -18,6 +18,7 @@
 import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { BUNMASKA_VERSION } from '../common/version';
+import { copyAppAssets } from './app-assets';
 import { bundleIdSlug } from './build-macos';
 import { buildZipArchive, type ZipEntry } from './zip';
 
@@ -211,6 +212,9 @@ export const buildWindowsApp = async (
     ...(opts.icon !== undefined ? { icon: opts.icon } : {}),
   };
   await compileWindowsBinary(opts.entry, layout.exePath, meta);
+
+  // Ship the entry's runtime assets (the page, the preload) beside the binary.
+  copyAppAssets(opts.entry, layout.appDir);
 
   // Bake the engine-id the app pins, read at launch by the engine resolver.
   writeFileSync(layout.engineIdPath, `${opts.engineId ?? 'system'}\n`);

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -50,11 +50,18 @@ export default defineConfig({
 `;
 
 const mainTs = (vars: TemplateVars): string =>
-  `import { join } from 'node:path';
+  `import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { app, BrowserWindow, ipcMain } from 'bunmaska';
 
 // A demo handler the preload exposes to the page as window.api.ping().
 ipcMain.handle('ping', () => 'pong');
+
+// Under \`bunmaska dev\` the assets sit next to this file; a built app ships them
+// beside the executable.
+const assetDir = existsSync(join(import.meta.dir, 'index.html'))
+  ? import.meta.dir
+  : dirname(process.execPath);
 
 const createWindow = (): void => {
   const win = new BrowserWindow({
@@ -62,10 +69,10 @@ const createWindow = (): void => {
     height: 680,
     title: ${JSON.stringify(vars.name)},
     webPreferences: {
-      preload: join(import.meta.dir, 'preload.js'),
+      preload: join(assetDir, 'preload.js'),
     },
   });
-  win.loadFile(join(import.meta.dir, 'index.html'));
+  win.loadFile(join(assetDir, 'index.html'));
 };
 
 app.whenReady().then(createWindow);

--- a/src/main/platform/macos/cocoa-backend.ts
+++ b/src/main/platform/macos/cocoa-backend.ts
@@ -71,6 +71,13 @@ const log = createLogger('macos-backend');
 
 const NS_BACKING_STORE_BUFFERED = 2n;
 const NS_ACTIVATION_POLICY_REGULAR = 0n;
+
+/** `NSEventMaskAny` (NSUIntegerMax): dequeue every kind of AppKit event. */
+const NS_EVENT_MASK_ANY: Handle = 0xffffffffffffffffn;
+/** `dequeue:YES` for `nextEventMatchingMask:`. */
+const DEQUEUE_YES: Handle = 1n;
+/** Upper bound on events dispatched per pump tick, so a flood can't starve Bun. */
+const APP_EVENT_BUDGET = 256;
 /** `NSWindowStyleMaskFullScreen` (1 << 14). */
 const NS_FULLSCREEN_STYLE_MASK = 16384n;
 /** `NSWindowStyleMaskResizable` (1 << 3). */
@@ -585,7 +592,11 @@ class MacOSWindow implements NativeWindow {
   }
 
   show(): void {
-    msgSendPtr(this.#window, cocoa().selectors.get('makeKeyAndOrderFront:'), 0n);
+    const rt = cocoa();
+    msgSendPtr(this.#window, rt.selectors.get('makeKeyAndOrderFront:'), 0n);
+    // Activate the app so the shown window comes to the foreground.
+    const app = rt.msgSend(rt.classes.get('NSApplication'), rt.selectors.get('sharedApplication'));
+    msgSendU8(app, rt.selectors.get('activateIgnoringOtherApps:'), 1);
     // AppKit has no `windowDidShow:` notification, so `show` is emitted here. A
     // becomeKey notification also fires `focus` via the delegate.
     this.emitEvent('show');
@@ -717,6 +728,11 @@ class MacOSApplication implements NativeApplication {
   #onActivate: ((hasVisibleWindows: boolean) => void) | undefined;
   #onOpenUrl: ((url: string) => void) | undefined;
   #onOpenFile: ((path: string) => void) | undefined;
+  // Handles the cooperative pump uses to dispatch AppKit input events each tick.
+  #nextEventSel: Handle = 0n;
+  #sendEventSel: Handle = 0n;
+  #distantPast: Handle = 0n;
+  #eventPumpMode: Handle = 0n;
 
   start(): void {
     if (this.#started) {
@@ -738,7 +754,14 @@ class MacOSApplication implements NativeApplication {
     rt.msgSend(this.#app, rt.selectors.get('finishLaunching'));
     msgSendU8(this.#app, rt.selectors.get('activateIgnoringOtherApps:'), 1);
 
-    this.#pump = new CooperativePump(createMacOSDrain());
+    // `nextEventMatchingMask:` runs every pump tick; cache its arguments. The
+    // mode string is autoreleased, so retain it for the app's lifetime.
+    this.#nextEventSel = rt.selectors.get('nextEventMatchingMask:untilDate:inMode:dequeue:');
+    this.#sendEventSel = rt.selectors.get('sendEvent:');
+    this.#distantPast = rt.msgSend(rt.classes.get('NSDate'), rt.selectors.get('distantPast'));
+    this.#eventPumpMode = rt.msgSend(nsString('kCFRunLoopDefaultMode'), rt.selectors.get('retain'));
+
+    this.#pump = new CooperativePump(createMacOSDrain(() => this.#pumpAppEvents()));
     this.#pump.start();
     this.#started = true;
     log.info('application started');
@@ -747,6 +770,31 @@ class MacOSApplication implements NativeApplication {
     this.#readyCallbacks = [];
     for (const callback of callbacks) {
       callback();
+    }
+  }
+
+  /**
+   * Deliver pending AppKit input events to their windows — the standard
+   * `nextEventMatchingMask:` / `sendEvent:` loop, run non-blockingly
+   * (`untilDate:` distantPast) so it drains the queue and returns each tick.
+   */
+  #pumpAppEvents(): void {
+    if (this.#app === 0n) {
+      return;
+    }
+    for (let i = 0; i < APP_EVENT_BUDGET; i += 1) {
+      const event = msgSendPtr4(
+        this.#app,
+        this.#nextEventSel,
+        NS_EVENT_MASK_ANY,
+        this.#distantPast,
+        this.#eventPumpMode,
+        DEQUEUE_YES,
+      );
+      if (event === 0n) {
+        break;
+      }
+      msgSendPtr(this.#app, this.#sendEventSel, event);
     }
   }
 

--- a/src/main/platform/macos/cocoa-run-loop.ts
+++ b/src/main/platform/macos/cocoa-run-loop.ts
@@ -6,11 +6,11 @@ import { bigIntOut, LIBOBJC_PATH, macOSLibraryAccessor, ptrIn } from './objc';
  * macOS native run-loop drain.
  *
  * Provides the non-blocking "drain once" function the {@link CooperativePump}
- * calls each tick. It runs `CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true)`
- * repeatedly until the loop reports it has nothing left to handle, then
- * returns — the AppKit loop is serviced without ever blocking Bun's thread
- * (D020). Each drain is wrapped in an autorelease pool so per-event temporary
- * objects are released promptly.
+ * calls each tick: it dispatches pending AppKit input events (via the
+ * `pumpEvents` callback), then runs `CFRunLoopRunInMode(kCFRunLoopDefaultMode,
+ * 0, true)` until the loop has nothing left to handle. The AppKit loop is
+ * serviced without ever blocking Bun's thread. Each drain is wrapped in an
+ * autorelease pool so per-tick temporary objects are released promptly.
  */
 
 const CORE_FOUNDATION_PATH = '/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation';
@@ -48,7 +48,7 @@ const getAutoreleasePool = macOSLibraryAccessor('libobjc autorelease pool', () =
  * any non-macOS host (via the lazy accessors). The returned function is cheap
  * to call repeatedly and never blocks.
  */
-export const createMacOSDrain = (): (() => void) => {
+export const createMacOSDrain = (pumpEvents?: () => void): (() => void) => {
   const cf = getCoreFoundation();
   const pool = getAutoreleasePool();
   const mode = bigIntOut(
@@ -62,6 +62,7 @@ export const createMacOSDrain = (): (() => void) => {
   return () => {
     const poolToken = pool.symbols.objc_autoreleasePoolPush();
     try {
+      pumpEvents?.();
       for (let i = 0; i < DRAIN_BUDGET; i += 1) {
         const result = cf.symbols.CFRunLoopRunInMode(ptrIn(mode), 0, 1);
         if (result !== CF_RUN_LOOP_RUN_HANDLED_SOURCE) {

--- a/tests/unit/cli/app-assets.test.ts
+++ b/tests/unit/cli/app-assets.test.ts
@@ -1,0 +1,52 @@
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, test } from 'bun:test';
+import { copyAppAssets, isRuntimeAsset } from '../../../src/cli/app-assets';
+
+describe('isRuntimeAsset', () => {
+  test('keeps page, preload, styles, images and data', () => {
+    expect(isRuntimeAsset('index.html')).toBe(true);
+    expect(isRuntimeAsset('preload.js')).toBe(true);
+    expect(isRuntimeAsset('styles.css')).toBe(true);
+    expect(isRuntimeAsset('icon.png')).toBe(true);
+    expect(isRuntimeAsset('data.json')).toBe(true);
+  });
+
+  test('excludes TypeScript sources (compiled into the binary)', () => {
+    expect(isRuntimeAsset('main.ts')).toBe(false);
+    expect(isRuntimeAsset('component.tsx')).toBe(false);
+    expect(isRuntimeAsset('mod.mts')).toBe(false);
+    expect(isRuntimeAsset('mod.cts')).toBe(false);
+  });
+
+  test('excludes node_modules', () => {
+    expect(isRuntimeAsset('node_modules')).toBe(false);
+  });
+});
+
+describe('copyAppAssets', () => {
+  test('copies sibling assets, not TS sources or the entry', () => {
+    const root = mkdtempSync(join(tmpdir(), 'bunmaska-assets-'));
+    const source = join(root, 'src');
+    const destination = join(root, 'out');
+    mkdirSync(source, { recursive: true });
+    mkdirSync(destination, { recursive: true });
+    writeFileSync(join(source, 'main.ts'), '// entry');
+    writeFileSync(join(source, 'eval.ts'), '// compiled in');
+    writeFileSync(join(source, 'preload.js'), '// preload');
+    writeFileSync(join(source, 'index.html'), '<!doctype html>');
+
+    const copied = copyAppAssets(join(source, 'main.ts'), destination).sort();
+
+    expect(copied).toEqual(['index.html', 'preload.js']);
+    expect(existsSync(join(destination, 'index.html'))).toBe(true);
+    expect(existsSync(join(destination, 'preload.js'))).toBe(true);
+    expect(existsSync(join(destination, 'main.ts'))).toBe(false);
+    expect(existsSync(join(destination, 'eval.ts'))).toBe(false);
+  });
+
+  test('returns empty when the entry directory is absent', () => {
+    expect(copyAppAssets('/no/such/dir/main.ts', tmpdir())).toEqual([]);
+  });
+});

--- a/tests/unit/cli/codesign.test.ts
+++ b/tests/unit/cli/codesign.test.ts
@@ -4,19 +4,23 @@ import {
   buildCodesignVerifyArgs,
   buildNotarizeArgs,
   buildStapleArgs,
+  codesignEntitlements,
 } from '../../../src/cli/build-macos';
 
 describe('buildCodesignArgs', () => {
   const appPath = '/tmp/out/My App.app';
+  const entitlements = '/tmp/ent/app.entitlements';
 
-  test('forces a deep signature with the hardened runtime for a real identity', () => {
+  test('forces a deep hardened-runtime signature with entitlements for a real identity', () => {
     const identity = 'Developer ID Application: Jane Doe (TEAMID123)';
-    const args = buildCodesignArgs(identity, appPath);
+    const args = buildCodesignArgs(identity, appPath, entitlements);
     expect(args).toEqual([
       '--force',
       '--deep',
       '--options',
       'runtime',
+      '--entitlements',
+      entitlements,
       '--sign',
       identity,
       appPath,
@@ -24,29 +28,45 @@ describe('buildCodesignArgs', () => {
   });
 
   test('enables the hardened runtime via --options runtime', () => {
-    const args = buildCodesignArgs('-', appPath);
+    const args = buildCodesignArgs('-', appPath, entitlements);
     const optionsIndex = args.indexOf('--options');
     expect(optionsIndex).toBeGreaterThanOrEqual(0);
     expect(args[optionsIndex + 1]).toBe('runtime');
   });
 
+  test('passes the entitlements file right after --entitlements', () => {
+    const args = buildCodesignArgs('-', appPath, entitlements);
+    const index = args.indexOf('--entitlements');
+    expect(index).toBeGreaterThanOrEqual(0);
+    expect(args[index + 1]).toBe(entitlements);
+  });
+
   test('passes the identity verbatim right after --sign', () => {
     const identity = 'Developer ID Application: Jane Doe (TEAMID123)';
-    const args = buildCodesignArgs(identity, appPath);
+    const args = buildCodesignArgs(identity, appPath, entitlements);
     const signIndex = args.indexOf('--sign');
     expect(signIndex).toBeGreaterThanOrEqual(0);
     expect(args[signIndex + 1]).toBe(identity);
   });
 
   test('passes the ad-hoc - identity through unchanged', () => {
-    const args = buildCodesignArgs('-', appPath);
+    const args = buildCodesignArgs('-', appPath, entitlements);
     const signIndex = args.indexOf('--sign');
     expect(args[signIndex + 1]).toBe('-');
   });
 
   test('targets the app bundle path as the final argument', () => {
-    const args = buildCodesignArgs('-', appPath);
+    const args = buildCodesignArgs('-', appPath, entitlements);
     expect(args.at(-1)).toBe(appPath);
+  });
+});
+
+describe('codesignEntitlements', () => {
+  test('grants the JIT/FFI exceptions Bun needs under the hardened runtime', () => {
+    const xml = codesignEntitlements();
+    expect(xml).toContain('com.apple.security.cs.allow-jit');
+    expect(xml).toContain('com.apple.security.cs.allow-unsigned-executable-memory');
+    expect(xml).toContain('com.apple.security.cs.disable-library-validation');
   });
 });
 


### PR DESCRIPTION
Building a calculator and running it exposed four real bugs that each broke a packaged macOS app. Fixed all four; `bunmaska build` now produces a working, signed, interactive `.app` from one command (verified end to end: window shows, keyboard/mouse work, `9×9 = 81`).

## The four fixes

1. **Window never appeared.** The app was activated once at startup, before any window existed. `MacOSWindow.show()` now activates the app when a window is shown, so a bundled `.app` comes to the foreground.
2. **App was dead to input.** The cooperative run-loop ran `CFRunLoopRunInMode` (which renders) but never dispatched `NSApp` events, so clicks/keys were never delivered. The drain now runs the standard `nextEventMatchingMask:` / `sendEvent:` loop non-blockingly each tick.
3. **Built app crashed (exit 133) — missing assets.** `bun build --compile` embeds JS but not runtime-loaded files. `bunmaska build` now copies the entry's sibling assets (HTML, preload, CSS, images) beside the executable, and the scaffold resolves them via `process.execPath` when compiled.
4. **Signed app crashed (SIGTRAP) — JIT entitlements.** `codesign --options runtime` enabled the Hardened Runtime without the entitlements Bun needs, so the app trapped on its first FFI call. The codesign step now grants `allow-jit`, `allow-unsigned-executable-memory`, and `disable-library-validation`.

Bumps to `0.1.0-alpha.4`. Validate green (1596 tests, 0 fail); new unit tests cover the asset predicate and the codesign entitlements.

> Note: the run-loop is still a 60Hz cooperative poll. Replacing it with an event-driven `CFRunLoop` integration is a separate, focused follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)