### PR TITLE
docs: bump the site to 0.1.0-alpha.4 + changelog entry

### DIFF
--- a/website/src/content/docs/changelog.md
+++ b/website/src/content/docs/changelog.md
@@ -4,13 +4,30 @@ description: Bunmaska is pre-release, so this is one honest snapshot rather than
 order: 2
 ---
 
-The current version is **`0.1.0-alpha.2`**. It is **not yet published to npm** - this page is a hardcoded snapshot of the alpha. Once the framework ships publicly, every release will get a proper dated entry here (semver, highlights, breaking changes, fixes).
+The current version is **`0.1.0-alpha.4`**, live on npm - `npm i bunmaska`. Newest first; still a curated snapshot rather than a per-commit log.
 
-## Unreleased - the Windows backend
+## `0.1.0-alpha.4`
 
-Bunmaska became cross-platform on three OSes: a full **Windows** backend landed on `main`.
+macOS packaged apps now actually work. Building a real app surfaced four bugs that each broke a double-clickable `.app`; all four are fixed, so `bunmaska build` produces a window that opens and responds to clicks and keys.
+
+**Fixes**
+
+- **Windows now appear.** A bundled app is brought to the foreground when its first window is shown, not only once at startup before any window exists.
+- **Apps respond to input.** The macOS run loop now dispatches AppKit mouse and keyboard events (`nextEventMatchingMask:` / `sendEvent:`) each tick - the window used to render but ignore clicks.
+- **Built apps no longer crash on launch.** `bunmaska build` copies your runtime assets (the page, the preload, CSS, images) beside the executable, and the scaffold resolves them by the executable's path when compiled - a compiled binary can't read files from `import.meta.dir`.
+- **Signed apps no longer trap.** Code-signing grants the JIT entitlements Bun needs (`allow-jit`, `allow-unsigned-executable-memory`, `disable-library-validation`); without them a hardened-runtime app died on its first FFI call.
+
+**Known limit**
+
+- The macOS run loop is a cooperative ~60 Hz poll - complete and correct, but not yet event-driven (so up to ~16 ms input latency). An event-driven `CFRunLoop` integration is the next focused change.
+
+## `0.1.0-alpha.3`
+
+The first npm release - and Bunmaska became cross-platform on three OSes with a full **Windows** backend landed on `main`.
 
 **Highlights**
+
+- **Published to npm** - `npm i bunmaska`.
 
 - **Win32 + WinCairo WebKit runtime** in pure `bun:ffi` - native windows + a cooperative message pump, the WinCairo WebKit view, renderer↔main IPC with context isolation, an **application menu bar**, and the secondary modules: clipboard (text/HTML/**images**), dialogs, menus, tray, notifications, `safeStorage` (DPAPI), screen, shell, global shortcuts, power monitor/blocker, native theme, and `session.clearStorageData`. Green on a `windows-latest` CI runner next to macOS and Linux.
 - **From-source WinCairo engine** - we compile WebKit's WinCairo port from source (a clang-cl build), relocate it into the engine store, and proved a real `BrowserWindow` loads + runs JS from the store with no system WebKit (`STORE_ENGINE_OK`). A reproducible build script + CI workflow ship with it.

--- a/website/src/layouts/Base.astro
+++ b/website/src/layouts/Base.astro
@@ -1,6 +1,7 @@
 ---
 import "../fonts";
 import "../styles/global.css";
+import { VERSION } from "../site";
 
 interface Props {
   title?: string;
@@ -24,10 +25,10 @@ const jsonLd = {
   "@type": "SoftwareApplication",
   name: "Bunmaska",
   applicationCategory: "DeveloperApplication",
-  operatingSystem: "macOS, Linux",
+  operatingSystem: "macOS, Linux, Windows",
   description,
   url: Astro.site?.href,
-  softwareVersion: "0.1.0-alpha.2",
+  softwareVersion: VERSION,
   license: "https://opensource.org/licenses/MIT",
   offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
 };

--- a/website/src/pages/roadmap.astro
+++ b/website/src/pages/roadmap.astro
@@ -3,6 +3,7 @@ import Base from "../layouts/Base.astro";
 import Nav from "../components/Nav.astro";
 import Footer from "../components/Footer.astro";
 import { Icon } from "astro-icon/components";
+import { VERSION } from "../site";
 
 const HEAD = "text-[1.5rem] leading-[1.2] font-semibold tracking-tight";
 const DISPLAY = "font-serif leading-[1.04] text-balance text-[clamp(2.5rem,5.5vw,3.5rem)]";
@@ -86,7 +87,7 @@ const phases: { status: Status; title: string; note?: string; items: string[] }[
           we're deliberately taking slowly. No vapor; if it isn't built, it says so.
         </p>
         <div class="mt-8 flex flex-wrap items-center justify-center gap-2">
-          <span class="tag">v0.1.0-alpha.2</span>
+          <span class="tag">v{VERSION}</span>
           <span class="tag">macOS · Linux · Windows</span>
           <span class="tag">MIT</span>
         </div>

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -1,4 +1,4 @@
 // Single source of truth for site-wide constants.
-export const VERSION = "0.1.0-alpha.2";
+export const VERSION = "0.1.0-alpha.4";
 export const GITHUB = "https://github.com/ipfizz/bunmaska";
 export const NPM = "https://www.npmjs.com/package/bunmaska";


### PR DESCRIPTION
The docs still showed `0.1.0-alpha.2`. Brings everything to `alpha.4`:

- `site.ts` `VERSION` → `0.1.0-alpha.4` (drives the Nav + Footer).
- **Changelog:** drops the stale "not yet published to npm" intro, adds a **`0.1.0-alpha.4`** entry (the four macOS packaged-app fixes) and a **`0.1.0-alpha.3`** entry (first npm release + the Windows backend, promoted from "Unreleased").
- Roadmap version tag and the SEO `softwareVersion` now read from the `VERSION` constant instead of a hardcoded string, so they can't drift again. SEO `operatingSystem` now includes Windows.

Build green (41 pages). Merging deploys to bunmaska.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)