### PR TITLE
release: 0.1.0-alpha.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Most core modules behave the same. Anything not yet implemented throws an action
 
 ## Status
 
-**Alpha** — `0.1.0-alpha.3`. If you are already running this in production, we admire your courage and decline all responsibility. If you are a large company doing an evaluation, please read the word "alpha" three more times before proceeding. If it is still 2027 and this file still opens with "alpha," feel free to open an issue titled "are you OK".
+**Alpha** — `0.1.0-alpha.5`. If you are already running this in production, we admire your courage and decline all responsibility. If you are a large company doing an evaluation, please read the word "alpha" three more times before proceeding. If it is still 2027 and this file still opens with "alpha," feel free to open an issue titled "are you OK".
 
 ## Documentation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunmaska",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "A drop-in replacement for Electron, built on Bun and system WebKit.",
   "keywords": [
     "electron",

--- a/website/src/content/docs/changelog.md
+++ b/website/src/content/docs/changelog.md
@@ -4,7 +4,24 @@ description: Bunmaska is pre-release, so this is one honest snapshot rather than
 order: 2
 ---
 
-The current version is **`0.1.0-alpha.4`**, live on npm - `npm i bunmaska`. Newest first; still a curated snapshot rather than a per-commit log.
+The current version is **`0.1.0-alpha.5`**, live on npm - `npm i bunmaska`. Newest first; still a curated snapshot rather than a per-commit log.
+
+## `0.1.0-alpha.5`
+
+Frameless windows, a real preload, and a dev loop that doesn't blink.
+
+**Highlights**
+
+- **Custom frameless title bars.** `frame: false` windows get an app-region drag handle and built-in window controls, shared across platforms - native drag on macOS, real controls on Windows. See [Frameless Windows](/docs/concepts/frameless-windows).
+- **Preloads can import.** The preload is now bundled before injection, so `import`s in your preload work instead of silently breaking `window.api`.
+- **`BrowserWindow.setPosition` / `setBounds`** - full on Windows, best-effort on macOS and Linux.
+- **Live reload in dev.** `bunmaska dev` reloads the renderer when assets change instead of restarting the whole app.
+
+**Fixes**
+
+- `bunmaska build` skips dotfiles and never copies the build output into itself when collecting runtime assets.
+- Windows web view is sized to the client area, so content is no longer clipped by the window frame.
+- The frameless title-bar script no longer leaks `__bunmaska` into the page world on macOS and Linux.
 
 ## `0.1.0-alpha.4`
 

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -1,5 +1,5 @@
 // Single source of truth for site-wide constants.
 
-export const VERSION = "0.1.0-alpha.4";
+export const VERSION = "0.1.0-alpha.5";
 export const GITHUB = "https://github.com/ipfizz/bunmaska";
 export const NPM = "https://www.npmjs.com/package/bunmaska";


### PR DESCRIPTION
Bumps the version to **`0.1.0-alpha.5`** and documents it. Tested on macOS: the framework validates green (1623 tests), and `bunmaska build` produces a working, signed, interactive packaged `.app` end-to-end (verified `6×7=42` via synthetic input, window on screen, JIT entitlements + assets applied by the build in one command).

- `package.json` → `0.1.0-alpha.5`
- README Status line → `0.1.0-alpha.5` (was stale at alpha.3)
- `site.ts` `VERSION` → `0.1.0-alpha.5` (drives Nav + Footer)
- **Changelog** `0.1.0-alpha.5` entry: frameless windows + custom title bars, preload bundling (imports work), `setPosition`/`setBounds`, dev live-reload, and the asset/web-view fixes — all of which landed on `main` since alpha.4.

Merging deploys the docs to bunmaska.org; npm republish (`npm publish` from root) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)