### PR TITLE
Event-driven macOS run loop: sleep-until-input instead of a 60 Hz poll

### DIFF
--- a/src/main/platform/macos/cocoa-backend.ts
+++ b/src/main/platform/macos/cocoa-backend.ts
@@ -7,7 +7,7 @@ import {
   generatePageWorldStub,
 } from '../../../renderer/api/cross-world-bridge';
 import { generatePreloadBootstrap } from '../../../renderer/preload-bootstrap';
-import { CooperativePump } from '../../run-loop';
+import { AdaptiveBlockingPump } from '../../run-loop';
 import type {
   NativeAppKit,
   NativeApplication,
@@ -739,7 +739,7 @@ class MacOSApplication implements NativeApplication {
   #started = false;
   #app: Handle = 0n;
   #appDelegate: Handle = 0n;
-  #pump: CooperativePump | undefined;
+  #pump: AdaptiveBlockingPump | undefined;
   #readyCallbacks: Array<() => void> = [];
   #onActivate: ((hasVisibleWindows: boolean) => void) | undefined;
   #onOpenUrl: ((url: string) => void) | undefined;
@@ -777,7 +777,7 @@ class MacOSApplication implements NativeApplication {
     this.#distantPast = rt.msgSend(rt.classes.get('NSDate'), rt.selectors.get('distantPast'));
     this.#eventPumpMode = rt.msgSend(nsString('kCFRunLoopDefaultMode'), rt.selectors.get('retain'));
 
-    this.#pump = new CooperativePump(createMacOSDrain(() => this.#pumpAppEvents()));
+    this.#pump = new AdaptiveBlockingPump(createMacOSDrain(() => this.#pumpAppEvents()));
     this.#pump.start();
     this.#started = true;
     log.info('application started');

--- a/src/main/platform/macos/cocoa-run-loop.ts
+++ b/src/main/platform/macos/cocoa-run-loop.ts
@@ -5,12 +5,14 @@ import { bigIntOut, LIBOBJC_PATH, macOSLibraryAccessor, ptrIn } from './objc';
 /**
  * macOS native run-loop drain.
  *
- * Provides the non-blocking "drain once" function the {@link CooperativePump}
- * calls each tick: it dispatches pending AppKit input events (via the
- * `pumpEvents` callback), then runs `CFRunLoopRunInMode(kCFRunLoopDefaultMode,
- * 0, true)` until the loop has nothing left to handle. The AppKit loop is
- * serviced without ever blocking Bun's thread. Each drain is wrapped in an
- * autorelease pool so per-tick temporary objects are released promptly.
+ * Returns a function the {@link AdaptiveBlockingPump} calls each tick with a
+ * timeout: it dispatches pending AppKit input events (via `pumpEvents`), then
+ * sleeps in `CFRunLoopRunInMode(kCFRunLoopDefaultMode, timeout, true)` until a
+ * native source is handled or the timeout elapses. A UI event returns it
+ * immediately (returnAfterSourceHandled), so the thread sleeps when idle yet
+ * wakes the instant input arrives. Returns whether a source was handled — the
+ * pump stays responsive while that holds and backs off when it doesn't. Each
+ * drain runs inside an autorelease pool so per-tick temporaries are released.
  */
 
 const CORE_FOUNDATION_PATH = '/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation';
@@ -48,7 +50,7 @@ const getAutoreleasePool = macOSLibraryAccessor('libobjc autorelease pool', () =
  * any non-macOS host (via the lazy accessors). The returned function is cheap
  * to call repeatedly and never blocks.
  */
-export const createMacOSDrain = (pumpEvents?: () => void): (() => void) => {
+export const createMacOSDrain = (pumpEvents?: () => void): ((timeoutMs: number) => boolean) => {
   const cf = getCoreFoundation();
   const pool = getAutoreleasePool();
   const mode = bigIntOut(
@@ -59,16 +61,24 @@ export const createMacOSDrain = (pumpEvents?: () => void): (() => void) => {
     ),
   );
 
-  return () => {
+  return (timeoutMs: number) => {
     const poolToken = pool.symbols.objc_autoreleasePoolPush();
     try {
       pumpEvents?.();
-      for (let i = 0; i < DRAIN_BUDGET; i += 1) {
-        const result = cf.symbols.CFRunLoopRunInMode(ptrIn(mode), 0, 1);
-        if (result !== CF_RUN_LOOP_RUN_HANDLED_SOURCE) {
-          break;
+      const handled =
+        cf.symbols.CFRunLoopRunInMode(ptrIn(mode), timeoutMs / 1000, 1) ===
+        CF_RUN_LOOP_RUN_HANDLED_SOURCE;
+      if (handled) {
+        // Dispatch the event that woke us, then clear any other ready sources
+        // without blocking so a burst is handled in this tick.
+        pumpEvents?.();
+        for (let i = 0; i < DRAIN_BUDGET; i += 1) {
+          if (cf.symbols.CFRunLoopRunInMode(ptrIn(mode), 0, 1) !== CF_RUN_LOOP_RUN_HANDLED_SOURCE) {
+            break;
+          }
         }
       }
+      return handled;
     } finally {
       pool.symbols.objc_autoreleasePoolPop(poolToken);
     }

--- a/src/main/run-loop.ts
+++ b/src/main/run-loop.ts
@@ -76,3 +76,90 @@ export class CooperativePump {
     }
   }
 }
+
+/** Yields to Bun's event loop once, then runs `tick`. Injected in tests. */
+export type TickScheduler = (tick: () => void) => void;
+
+export type AdaptiveBlockingPumpOptions = {
+  /** Drain timeout (ms) after a tick that handled events; kept small for a responsive UI. Default 8. */
+  readonly minTimeoutMs?: number;
+  /** Drain timeout (ms) an idle run backs off to; larger sleeps deeper for less CPU. Default 125. */
+  readonly maxTimeoutMs?: number;
+  /** Schedules the next tick after yielding to Bun's loop. Defaults to `setTimeout(tick, 0)`. */
+  readonly schedule?: TickScheduler;
+};
+
+const DEFAULT_MIN_TIMEOUT_MS = 8;
+const DEFAULT_MAX_TIMEOUT_MS = 125;
+
+const defaultScheduler: TickScheduler = (tick) => {
+  setTimeout(tick, 0);
+};
+
+/**
+ * Adaptive blocking run-loop pump.
+ *
+ * Drives a native drain that sleeps until a UI event or a timeout (see the
+ * platform `createDrain`). Each tick the drain blocks for the current timeout
+ * and reports whether it handled events; the pump then resets the timeout to
+ * its minimum (input is flowing — stay responsive) or doubles it toward the
+ * maximum (idle — sleep deeper for near-zero CPU). Between ticks it yields to
+ * Bun's loop so JS timers, microtasks and IO run. A UI event wakes the drain
+ * immediately, so input latency stays ~0 regardless of the idle backoff.
+ */
+export class AdaptiveBlockingPump {
+  readonly #drain: (timeoutMs: number) => boolean;
+  readonly #minTimeoutMs: number;
+  readonly #maxTimeoutMs: number;
+  readonly #schedule: TickScheduler;
+  #timeoutMs: number;
+  #running = false;
+
+  constructor(drain: (timeoutMs: number) => boolean, options?: AdaptiveBlockingPumpOptions) {
+    this.#drain = drain;
+    this.#minTimeoutMs = options?.minTimeoutMs ?? DEFAULT_MIN_TIMEOUT_MS;
+    this.#maxTimeoutMs = options?.maxTimeoutMs ?? DEFAULT_MAX_TIMEOUT_MS;
+    this.#schedule = options?.schedule ?? defaultScheduler;
+    this.#timeoutMs = this.#minTimeoutMs;
+  }
+
+  get isRunning(): boolean {
+    return this.#running;
+  }
+
+  /** The drain timeout (ms) the next tick will use. */
+  get timeoutMs(): number {
+    return this.#timeoutMs;
+  }
+
+  /** Begin pumping. Idempotent — a second call while running is a no-op. */
+  start(): void {
+    if (this.#running) {
+      return;
+    }
+    this.#running = true;
+    this.#tick();
+  }
+
+  /** Stop pumping. Idempotent — safe to call when not running. */
+  stop(): void {
+    this.#running = false;
+  }
+
+  #tick(): void {
+    if (!this.#running) {
+      return;
+    }
+    let active = false;
+    try {
+      active = this.#drain(this.#timeoutMs);
+    } catch (error) {
+      // A failure draining one tick must not tear down the whole pump.
+      log.error('drain tick threw', error);
+    }
+    this.#timeoutMs = active
+      ? this.#minTimeoutMs
+      : Math.min(this.#timeoutMs * 2, this.#maxTimeoutMs);
+    this.#schedule(() => this.#tick());
+  }
+}

--- a/tests/integration/macos/cocoa-run-loop.test.ts
+++ b/tests/integration/macos/cocoa-run-loop.test.ts
@@ -21,7 +21,7 @@ if (currentPlatform() === 'macos') {
     test('returns a drain function that runs many times without crashing', () => {
       const drain = createMacOSDrain();
       for (let i = 0; i < 50; i += 1) {
-        drain();
+        drain(0);
       }
       expect(typeof drain).toBe('function');
     });
@@ -49,7 +49,7 @@ if (currentPlatform() === 'macos') {
 
       const drain = createMacOSDrain();
       for (let i = 0; i < 60; i += 1) {
-        drain();
+        drain(0);
       }
 
       expect(msgSendReturnsU8(window, rt.selectors.get('isVisible'))).toBe(1);

--- a/tests/unit/main/run-loop.test.ts
+++ b/tests/unit/main/run-loop.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test';
-import { CooperativePump, type Ticker } from '../../../src/main/run-loop';
+import {
+  AdaptiveBlockingPump,
+  CooperativePump,
+  type Ticker,
+  type TickScheduler,
+} from '../../../src/main/run-loop';
 
 const manualTicker = (): { ticker: Ticker; tick: () => void; cancelled: () => boolean } => {
   let onTick: (() => void) | undefined;
@@ -124,5 +129,128 @@ describe('CooperativePump interval', () => {
     new CooperativePump(() => undefined, { ticker }).start();
     expect(seenMs).toBeGreaterThan(0);
     expect(seenMs).toBeLessThanOrEqual(32);
+  });
+});
+
+const manualScheduler = (): {
+  schedule: TickScheduler;
+  run: () => void;
+  pending: () => boolean;
+} => {
+  let next: (() => void) | undefined;
+  return {
+    schedule: (tick) => {
+      next = tick;
+    },
+    run: () => {
+      const tick = next;
+      next = undefined;
+      tick?.();
+    },
+    pending: () => next !== undefined,
+  };
+};
+
+describe('AdaptiveBlockingPump start / stop', () => {
+  test('is not running before start, running after', () => {
+    const pump = new AdaptiveBlockingPump(() => false, { schedule: manualScheduler().schedule });
+    expect(pump.isRunning).toBe(false);
+    pump.start();
+    expect(pump.isRunning).toBe(true);
+  });
+
+  test('start is idempotent — a second start does not drain twice', () => {
+    let drains = 0;
+    const pump = new AdaptiveBlockingPump(
+      () => {
+        drains += 1;
+        return false;
+      },
+      { schedule: manualScheduler().schedule },
+    );
+    pump.start();
+    pump.start();
+    expect(drains).toBe(1);
+  });
+
+  test('no draining occurs after stop', () => {
+    const s = manualScheduler();
+    let drains = 0;
+    const pump = new AdaptiveBlockingPump(
+      () => {
+        drains += 1;
+        return false;
+      },
+      { schedule: s.schedule },
+    );
+    pump.start();
+    pump.stop();
+    s.run();
+    expect(drains).toBe(1);
+    expect(pump.isRunning).toBe(false);
+  });
+});
+
+describe('AdaptiveBlockingPump adaptive timeout', () => {
+  test('starts at the minimum and drives the drain with the current timeout', () => {
+    const s = manualScheduler();
+    const seen: number[] = [];
+    const pump = new AdaptiveBlockingPump(
+      (ms) => {
+        seen.push(ms);
+        return false;
+      },
+      { minTimeoutMs: 10, maxTimeoutMs: 40, schedule: s.schedule },
+    );
+    pump.start();
+    s.run();
+    s.run();
+    expect(seen).toEqual([10, 20, 40]);
+  });
+
+  test('backs off exponentially toward the max while idle, then caps', () => {
+    const s = manualScheduler();
+    const pump = new AdaptiveBlockingPump(() => false, {
+      minTimeoutMs: 8,
+      maxTimeoutMs: 64,
+      schedule: s.schedule,
+    });
+    pump.start();
+    expect(pump.timeoutMs).toBe(16);
+    s.run();
+    expect(pump.timeoutMs).toBe(32);
+    s.run();
+    expect(pump.timeoutMs).toBe(64);
+    s.run();
+    expect(pump.timeoutMs).toBe(64);
+  });
+
+  test('snaps back to the minimum when a tick handles events', () => {
+    const s = manualScheduler();
+    let active = false;
+    const pump = new AdaptiveBlockingPump(() => active, {
+      minTimeoutMs: 8,
+      maxTimeoutMs: 64,
+      schedule: s.schedule,
+    });
+    pump.start();
+    s.run();
+    expect(pump.timeoutMs).toBeGreaterThan(8);
+    active = true;
+    s.run();
+    expect(pump.timeoutMs).toBe(8);
+  });
+
+  test('a throwing drain does not stop the pump and still reschedules', () => {
+    const s = manualScheduler();
+    const pump = new AdaptiveBlockingPump(
+      () => {
+        throw new Error('native hiccup');
+      },
+      { schedule: s.schedule },
+    );
+    pump.start();
+    expect(pump.isRunning).toBe(true);
+    expect(s.pending()).toBe(true);
   });
 });

--- a/website/src/content/docs/changelog.md
+++ b/website/src/content/docs/changelog.md
@@ -6,6 +6,12 @@ order: 2
 
 The current version is **`0.1.0-alpha.5`**, live on npm - `npm i bunmaska`. Newest first; still a curated snapshot rather than a per-commit log.
 
+## Unreleased
+
+**Event-driven macOS run loop.** The cooperative pump no longer polls AppKit at a fixed 60 Hz. It sleeps in `CFRunLoopRunInMode` until a native event arrives - input wakes it instantly - and backs off adaptively when idle. On an idle window that is roughly **10x less CPU** (~2.5% → ~0.2%) with no added input latency. One honest trade-off: while the UI is idle, *main-process* JS timers run at up to ~125 ms granularity (renderer `requestAnimationFrame` and IPC are unaffected - they ride the native event path).
+
+A true libuv-style integration like Electron's is not possible from pure `bun:ffi` today: Bun's loop is uSockets, not libuv, and its tick/wakeup primitives are not exported ([oven-sh/bun#18546](https://github.com/oven-sh/bun/issues/18546)). This is the best event-driven behavior achievable while staying single-threaded.
+
 ## `0.1.0-alpha.5`
 
 Frameless windows, a real preload, and a dev loop that doesn't blink.


### PR DESCRIPTION
## What

The macOS cooperative pump polled AppKit at a fixed **60 Hz** (`CFRunLoopRunInMode(…, timeout=0)` on a 16 ms `setInterval`). This replaces that with an **event-driven, adaptive** loop:

- The drain now **sleeps** in `CFRunLoopRunInMode(default, timeout, returnAfterSourceHandled)` — a native UI event returns it **instantly**, idle ticks just time out.
- A new **`AdaptiveBlockingPump`** drives it: timeout snaps to a small **min (8 ms)** while events flow (responsive) and **backs off exponentially to a max (125 ms)** when idle (deep sleep). It yields to Bun's loop between drains so JS timers/microtasks/IO still run.

## Measured on macOS (a real packaged calculator)

| | Before (60 Hz poll) | After (adaptive) |
|---|---|---|
| **Idle CPU** | ~2.5 % | **~0.2 %** (~10× lower) |
| Input latency (incl. from deep idle) | ≤16 ms | **~0** (CFRunLoop wakes on the event) |
| JS timer granularity while idle | ~50 ms | ~125 ms (= the max backoff) |
| `app.quit()` clean exit | ✓ | ✓ (pump stops, process exits) |

The one honest trade-off: while the UI is idle, **main-process** JS timers run at up to ~125 ms granularity. Renderer `requestAnimationFrame` (native `CADisplayLink`) and IPC are unaffected — they ride the native event path and keep the pump at min while active.

## Why not a true libuv/CFRunLoop embedding (Electron-style)?

Investigated thoroughly against the Bun + Electron sources. It is **not reachable from pure `bun:ffi` today**: Bun's main loop is uSockets (`us_loop_t`), not libuv; the exported `uv_*` are NAPI stubs (`uv_default_loop()` panics); and the real tick/wakeup symbols (`us_loop_run_bun_tick`, `us_wakeup_loop`) are not exported ([oven-sh/bun#18546](https://github.com/oven-sh/bun/issues/18546)). Blocking a native loop on the JS thread is also unsafe (JSC heap-access toggling). So this adaptive pump is the best event-driven behavior achievable while keeping bunmaska's single-pumped-thread identity. If Bun later exports those primitives, full integration becomes straightforward.

## Scope

macOS only by design — **Linux and Windows keep the existing `CooperativePump` untouched**. New: `AdaptiveBlockingPump` + 7 unit tests; the macOS drain returns a handled-source signal. Validate green (1630 tests, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)