### PR TITLE
fix: dev-loop hygiene and the electron named exports

### DIFF
--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -1,9 +1,10 @@
 /**
- * `bunmaska dev`: a TypeScript change restarts the `bun run <entry>` child; any
- * other watched file is a renderer asset and live-reloads the open windows.
+ * `bunmaska dev`: a change in the main-process graph restarts the
+ * `bun run <entry>` child; any other watched file is a renderer asset and
+ * live-reloads the open windows in place.
  */
 
-import { watch as fsWatch } from 'node:fs';
+import { readFileSync, watch as fsWatch } from 'node:fs';
 import { extname, resolve } from 'node:path';
 import type { BunmaskaConfig } from '../common/config-schema';
 import { InvalidArgumentError } from '../common/errors';
@@ -20,10 +21,36 @@ export const DEV_DEBOUNCE_MS = 120;
 export const resolveDevEntry = (config: BunmaskaConfig, explicit?: string): string =>
   explicit ?? config.entry ?? DEV_DEFAULT_ENTRY;
 
-const IGNORED_SEGMENTS: ReadonlySet<string> = new Set(['node_modules', '.git', 'dist']);
+/**
+ * Dependency, VCS and OUR-OWN-BUILD-OUTPUT directories. `dist` is deliberately NOT
+ * here: an app's renderer bundle lives there, and ignoring it meant a rebuilt
+ * bundle could never trigger a reload. The app bundles `bunmaska build` writes are
+ * ignored by suffix instead, because it defaults its output to the project root.
+ */
+const IGNORED_SEGMENTS: ReadonlySet<string> = new Set([
+  'node_modules',
+  '.git',
+  'build',
+  'out',
+  'coverage',
+]);
+
+/**
+ * Directory suffixes `bunmaska build` produces inside the watched root.
+ * ponytail: the Linux AppDir is a bare `<Name>/` with no suffix to match, so a
+ * Linux build during `dev` still churns; `--out` outside the root avoids it.
+ */
+const IGNORED_SEGMENT_SUFFIXES: readonly string[] = ['.app', '.AppDir'];
 
 /** TypeScript is compiled into the main process, so a change there restarts it. */
 const MAIN_SOURCE_EXTENSIONS: ReadonlySet<string> = new Set(['.ts', '.tsx', '.mts', '.cts']);
+
+/**
+ * The preload is read and bundled once, when the window is constructed, so a
+ * reload would re-inject the STALE script. Restarting is the honest action.
+ * Matches the shipped-asset convention in {@link ../cli/app-assets}.
+ */
+const PRELOAD_BASENAME = /^preload\.(?:js|mjs|cjs|ts)$/i;
 
 export type ChangeAction = 'restart' | 'reload' | 'ignore';
 
@@ -33,20 +60,60 @@ export type ChangeAction = 'restart' | 'reload' | 'ignore';
  */
 export const classifyChange = (relPath: string): ChangeAction => {
   const parts = relPath.split(/[\\/]/).filter((p) => p.length > 0);
-  if (parts.some((p) => IGNORED_SEGMENTS.has(p))) {
+  const ignored = (p: string): boolean =>
+    IGNORED_SEGMENTS.has(p) || IGNORED_SEGMENT_SUFFIXES.some((suffix) => p.endsWith(suffix));
+  if (parts.some(ignored)) {
     return 'ignore';
   }
   const base = parts[parts.length - 1] ?? '';
   if (base.length === 0 || base.startsWith('.')) {
     return 'ignore';
   }
+  if (PRELOAD_BASENAME.test(base)) {
+    return 'restart';
+  }
   return MAIN_SOURCE_EXTENSIONS.has(extname(base).toLowerCase()) ? 'restart' : 'reload';
+};
+
+/**
+ * Drop events whose file content did not actually change. `fs.watch` fires on a
+ * metadata-only touch, and a formatter that rewrites identical bytes fires too —
+ * both would otherwise restart the app.
+ *
+ * The FIRST event for a path has no baseline to compare against, so it always
+ * passes: the filter earns its keep from the second save onward, which is most
+ * of a session. A vanished file always passes through (a deletion is real).
+ * `readFile` is a seam so this tests without the filesystem.
+ */
+export const makeContentFilter = (
+  readFile: (relPath: string) => string | undefined,
+): ((relPath: string) => boolean) => {
+  const seen = new Map<string, string>();
+  return (relPath) => {
+    const contents = readFile(relPath);
+    if (contents === undefined) {
+      seen.delete(relPath);
+      return true;
+    }
+    const hash = String(Bun.hash(contents));
+    if (seen.get(relPath) === hash) {
+      return false;
+    }
+    seen.set(relPath, hash);
+    return true;
+  };
 };
 
 export type DevChild = {
   readonly kill: () => void;
   /** Ask the running child to live-reload its open windows (a renderer-only change). */
   readonly reload: () => void;
+  /**
+   * Settles when the process is really gone. Awaited before respawning: `kill()`
+   * only delivers a signal, so spawning immediately leaves two live apps racing
+   * for the window and the single-instance lock.
+   */
+  readonly exited?: Promise<unknown>;
 };
 export type DevWatcher = { readonly close: () => void };
 /** Timers; defaults to the global setTimeout/clearTimeout. */
@@ -72,6 +139,8 @@ export class DevSupervisor {
   #pending: unknown;
   #pendingAction: 'restart' | 'reload' | undefined;
   #stopped = false;
+  #restarting = false;
+  #alive = true;
   /** Number of times the child has been (re)started, including the first spawn. */
   starts = 1;
   reloads = 0;
@@ -80,7 +149,7 @@ export class DevSupervisor {
     this.#entry = entry;
     this.#deps = deps;
     this.#debounceMs = deps.debounceMs ?? DEV_DEBOUNCE_MS;
-    this.#child = deps.spawn(entry);
+    this.#child = this.#track(deps.spawn(entry));
     this.#watcher = deps.watch(dir, (relPath) => {
       this.#onChange(relPath);
     });
@@ -113,15 +182,49 @@ export class DevSupervisor {
     const action = this.#pendingAction ?? 'restart';
     this.#pendingAction = undefined;
     if (action === 'restart') {
-      this.#child.kill();
-      this.#child = this.#deps.spawn(this.#entry);
+      void this.#restart();
+      return;
+    }
+    // Reloading a child that already quit silently does nothing, and logging
+    // 'reloaded' at it is how the loop ends up pretending to drive a corpse.
+    if (!this.#alive) {
+      this.#deps.log('app is not running — edit a main-process file to restart it');
+      return;
+    }
+    this.#child.reload();
+    this.reloads += 1;
+    this.#deps.log('reloaded');
+  }
+
+  async #restart(): Promise<void> {
+    if (this.#restarting) {
+      return;
+    }
+    this.#restarting = true;
+    try {
+      const previous = this.#child;
+      previous.kill();
+      await previous.exited;
+      if (this.#stopped) {
+        return;
+      }
+      this.#child = this.#track(this.#deps.spawn(this.#entry));
       this.starts += 1;
       this.#deps.log(`restarted (${this.#entry})`);
-    } else {
-      this.#child.reload();
-      this.reloads += 1;
-      this.#deps.log('reloaded');
+    } finally {
+      this.#restarting = false;
     }
+  }
+
+  /** Mark the child live and watch for it exiting on its own (a user quit). */
+  #track(child: DevChild): DevChild {
+    this.#alive = true;
+    void child.exited?.then(() => {
+      if (this.#child === child) {
+        this.#alive = false;
+      }
+    });
+    return child;
   }
 
   /** Stop watching and kill the child. Idempotent. */
@@ -158,6 +261,7 @@ export const defaultDevDeps = (cwd: string, log: (message: string) => void): Dev
       stderr: 'inherit',
     });
     return {
+      exited: proc.exited,
       kill: () => {
         proc.kill();
       },
@@ -172,10 +276,23 @@ export const defaultDevDeps = (cwd: string, log: (message: string) => void): Dev
     };
   },
   watch: (dir, onChange) => {
-    const watcher = fsWatch(dir, { recursive: true }, (_event, filename) => {
-      if (filename !== null) {
-        onChange(filename.toString());
+    const changed = makeContentFilter((relPath) => {
+      try {
+        return readFileSync(resolve(dir, relPath), 'utf8');
+      } catch {
+        return undefined;
       }
+    });
+    const watcher = fsWatch(dir, { recursive: true }, (_event, filename) => {
+      if (filename === null) {
+        return;
+      }
+      const relPath = filename.toString();
+      // Classify before hashing so node_modules churn never costs a file read.
+      if (classifyChange(relPath) === 'ignore' || !changed(relPath)) {
+        return;
+      }
+      onChange(relPath);
     });
     return {
       close: () => {

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -249,13 +249,17 @@ const defaultTimers: DevTimers = {
   },
 };
 
-export const defaultDevDeps = (cwd: string, log: (message: string) => void): DevDeps => ({
+export const defaultDevDeps = (
+  cwd: string,
+  log: (message: string) => void,
+  extraEnv: Readonly<Record<string, string>> = {},
+): DevDeps => ({
   spawn: (entry) => {
     // `BUNMASKA_DEV` switches on the app's stdin reload listener; a piped stdin is
     // how the supervisor delivers reload requests to it.
     const proc = Bun.spawn(['bun', 'run', entry], {
       cwd,
-      env: { ...process.env, BUNMASKA_DEV: '1' },
+      env: { ...process.env, ...extraEnv, BUNMASKA_DEV: '1' },
       stdin: 'pipe',
       stdout: 'inherit',
       stderr: 'inherit',
@@ -313,13 +317,14 @@ export const runDev = async (
   entry: string,
   awaitStop: (stop: () => void) => Promise<void>,
   deps?: DevDeps,
+  extraEnv: Readonly<Record<string, string>> = {},
 ): Promise<void> => {
   const dir = resolve(targetDir);
   if (entry.trim().length === 0) {
     throw new InvalidArgumentError('bunmaska dev: entry must not be empty');
   }
   const effectiveDeps =
-    deps ?? defaultDevDeps(dir, (message) => process.stdout.write(`${message}\n`));
+    deps ?? defaultDevDeps(dir, (message) => process.stdout.write(`${message}\n`), extraEnv);
   const supervisor = new DevSupervisor(dir, entry, effectiveDeps);
   try {
     await awaitStop(() => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -327,6 +327,22 @@ const awaitInterrupt = (stop: () => void): Promise<void> =>
     process.once('SIGTERM', onSignal);
   });
 
+/**
+ * The engine env a launched app needs to resolve its `engine.webkit` pin. Only
+ * `build`/`doctor` used to read the pin, so `dev` and `run` silently launched on
+ * the system WebKit — which on Windows means no engine at all.
+ */
+const launchEngineEnv = async (): Promise<Record<string, string>> => {
+  try {
+    const { config } = await loadConfig(process.cwd());
+    const engineId = resolveBuildEngineId(config.engine?.webkit);
+    return engineId === 'system' ? {} : { BUNMASKA_WEBKIT_ID: engineId };
+  } catch {
+    // A missing or invalid config is the caller's problem to report, not ours.
+    return {};
+  }
+};
+
 const runDevCommand = async (command: Extract<Command, { kind: 'dev' }>): Promise<number> => {
   let entry: string;
   try {
@@ -337,7 +353,7 @@ const runDevCommand = async (command: Extract<Command, { kind: 'dev' }>): Promis
     return 1;
   }
   out(`bunmaska dev: running ${entry} (Ctrl-C to stop)`);
-  await runDev(process.cwd(), entry, awaitInterrupt);
+  await runDev(process.cwd(), entry, awaitInterrupt, undefined, await launchEngineEnv());
   return 0;
 };
 
@@ -355,7 +371,7 @@ export const dispatch = async (command: Command, deps: DispatchDeps = {}): Promi
     case 'dev':
       return await runDevCommand(command);
     case 'run':
-      return await runApp(command.entry, command.args);
+      return await runApp(command.entry, command.args, { extraEnv: await launchEngineEnv() });
     case 'build':
       return await runBuild(command, deps);
     case 'engine':

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -9,7 +9,10 @@ export type SpawnedChild = {
 
 export type Spawner = (
   command: readonly string[],
-  options: { readonly stdio: readonly ['inherit', 'inherit', 'inherit'] },
+  options: {
+    readonly stdio: readonly ['inherit', 'inherit', 'inherit'];
+    readonly env?: Readonly<Record<string, string | undefined>>;
+  },
 ) => SpawnedChild;
 
 const defaultSpawner: Spawner = (command, options) =>
@@ -17,17 +20,19 @@ const defaultSpawner: Spawner = (command, options) =>
     stdin: options.stdio[0],
     stdout: options.stdio[1],
     stderr: options.stdio[2],
+    ...(options.env !== undefined ? { env: options.env } : {}),
   });
 
 /** Resolves to the child's exit code. */
 export const runApp = async (
   entry: string,
   args: readonly string[],
-  deps: { readonly spawn?: Spawner } = {},
+  deps: { readonly spawn?: Spawner; readonly extraEnv?: Readonly<Record<string, string>> } = {},
 ): Promise<number> => {
   const spawn = deps.spawn ?? defaultSpawner;
   const child = spawn(['bun', 'run', entry, ...args], {
     stdio: ['inherit', 'inherit', 'inherit'],
+    ...(deps.extraEnv !== undefined ? { env: { ...process.env, ...deps.extraEnv } } : {}),
   });
   return await child.exited;
 };

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -22,5 +22,13 @@ export const createElectronShim = (
     },
   });
 
+/**
+ * Named re-exports, so the documented `import { app } from 'bunmaska/electron'`
+ * works. A named import of an unimplemented module fails at import time with a
+ * standard ESM error; the default export's Proxy is what turns a PROPERTY access
+ * into the actionable {@link notImplementedMessage}.
+ */
+export * from './index';
+
 const electron = createElectronShim();
 export default electron;

--- a/tests/unit/cli/dev.test.ts
+++ b/tests/unit/cli/dev.test.ts
@@ -4,6 +4,7 @@ import {
   DEV_DEFAULT_ENTRY,
   type DevDeps,
   DevSupervisor,
+  makeContentFilter,
   resolveDevEntry,
 } from '../../../src/cli/dev';
 
@@ -28,15 +29,33 @@ describe('classifyChange', () => {
   test('live-reloads on a renderer asset change', () => {
     expect(classifyChange('src/index.html')).toBe('reload');
     expect(classifyChange('src/styles.css')).toBe('reload');
-    expect(classifyChange('src/preload.js')).toBe('reload');
   });
 
-  test('ignores dependency/VCS/build dirs and dotfiles', () => {
+  test('restarts on a preload change, which a reload cannot pick up', () => {
+    // The preload is bundled once in the BrowserWindow constructor, so reloading
+    // re-injects the stale script.
+    expect(classifyChange('src/preload.js')).toBe('restart');
+    expect(classifyChange('app/preload.cjs')).toBe('restart');
+  });
+
+  test('reloads on a renderer bundle under dist', () => {
+    // Ignoring dist meant a rebuilt renderer could never reach the window.
+    expect(classifyChange('dist/renderer/assets/app.js')).toBe('reload');
+    expect(classifyChange('dist/renderer/index.html')).toBe('reload');
+  });
+
+  test('ignores dependency/VCS dirs and dotfiles', () => {
     expect(classifyChange('node_modules/x/index.js')).toBe('ignore');
     expect(classifyChange('.git/HEAD')).toBe('ignore');
-    expect(classifyChange('dist/app.js')).toBe('ignore');
     expect(classifyChange('src/.main.ts.swp')).toBe('ignore');
     expect(classifyChange('')).toBe('ignore');
+  });
+
+  test('ignores the app bundles bunmaska build writes into the project root', () => {
+    expect(classifyChange('MyApp.app/Contents/MacOS/index.html')).toBe('ignore');
+    expect(classifyChange('MyApp.AppDir/usr/bin/myapp')).toBe('ignore');
+    expect(classifyChange('build/x.js')).toBe('ignore');
+    expect(classifyChange('out/x.js')).toBe('ignore');
   });
 });
 
@@ -48,7 +67,7 @@ const makeHarness = (): {
   reloads: number;
   watcherClosed: () => boolean;
   fireChange: (relPath: string) => void;
-  runTimer: () => void;
+  runTimer: () => Promise<void>;
   pendingTimers: () => number;
 } => {
   const spawns: string[] = [];
@@ -100,7 +119,11 @@ const makeHarness = (): {
     },
     watcherClosed: () => closed,
     fireChange: (relPath) => onChange?.(relPath),
-    runTimer: () => timerFn?.(),
+    runTimer: async () => {
+      timerFn?.();
+      // A restart awaits the old child's `exited`; yield so it can finish.
+      await new Promise((r) => setTimeout(r, 0));
+    },
     pendingTimers: () => (timerFn === undefined ? 0 : 1),
   };
 };
@@ -112,34 +135,34 @@ describe('DevSupervisor', () => {
     expect(h.spawns).toEqual(['src/main.ts']);
   });
 
-  test('a TypeScript change restarts the child after the debounce fires', () => {
+  test('a TypeScript change restarts the child after the debounce fires', async () => {
     const h = makeHarness();
     const sup = new DevSupervisor('/proj', 'src/main.ts', h.deps);
     h.fireChange('src/main.ts');
     expect(h.spawns).toHaveLength(1); // not yet — debounced
-    h.runTimer();
+    await h.runTimer();
     expect(h.spawns).toEqual(['src/main.ts', 'src/main.ts']);
     expect(sup.starts).toBe(2);
     expect(sup.reloads).toBe(0);
   });
 
-  test('a renderer asset change live-reloads instead of restarting', () => {
+  test('a renderer asset change live-reloads instead of restarting', async () => {
     const h = makeHarness();
     const sup = new DevSupervisor('/proj', 'src/main.ts', h.deps);
     h.fireChange('src/index.html');
-    h.runTimer();
+    await h.runTimer();
     expect(h.spawns).toHaveLength(1); // no respawn — the window stays open
     expect(h.reloads).toBe(1);
     expect(sup.reloads).toBe(1);
     expect(sup.starts).toBe(1);
   });
 
-  test('a restart supersedes a reload coalesced into the same window', () => {
+  test('a restart supersedes a reload coalesced into the same window', async () => {
     const h = makeHarness();
     const sup = new DevSupervisor('/proj', 'src/main.ts', h.deps);
     h.fireChange('src/index.html'); // would reload
     h.fireChange('src/main.ts'); // but a TS change wins
-    h.runTimer();
+    await h.runTimer();
     expect(sup.starts).toBe(2);
     expect(h.reloads).toBe(0);
   });
@@ -151,13 +174,13 @@ describe('DevSupervisor', () => {
     expect(h.pendingTimers()).toBe(0);
   });
 
-  test('rapid changes coalesce into a single action', () => {
+  test('rapid changes coalesce into a single action', async () => {
     const h = makeHarness();
     new DevSupervisor('/proj', 'src/main.ts', h.deps);
     h.fireChange('src/a.ts');
     h.fireChange('src/b.ts');
     h.fireChange('src/c.ts');
-    h.runTimer();
+    await h.runTimer();
     expect(h.spawns).toHaveLength(2); // initial + one coalesced restart
   });
 
@@ -169,5 +192,122 @@ describe('DevSupervisor', () => {
     h.fireChange('src/main.ts');
     expect(h.pendingTimers()).toBe(0);
     expect(h.spawns).toHaveLength(1);
+  });
+});
+
+describe('DevSupervisor child lifecycle', () => {
+  /** A harness whose children expose a controllable `exited`. */
+  const makeLifecycle = () => {
+    const spawns: string[] = [];
+    const logs: string[] = [];
+    let settleLast: (() => void) | undefined;
+    let timerFn: (() => void) | undefined;
+    let onChange: ((relPath: string) => void) | undefined;
+    let reloads = 0;
+    const deps: DevDeps = {
+      spawn: (entry) => {
+        spawns.push(entry);
+        let settle: () => void = () => undefined;
+        const exited = new Promise<void>((r) => {
+          settle = r;
+        });
+        settleLast = settle;
+        return {
+          exited,
+          kill: () => undefined,
+          reload: () => {
+            reloads += 1;
+          },
+        };
+      },
+      watch: (_dir, cb) => {
+        onChange = cb;
+        return { close: () => undefined };
+      },
+      timers: {
+        set: (fn) => {
+          timerFn = fn;
+          return 1;
+        },
+        clear: () => {
+          timerFn = undefined;
+        },
+      },
+      log: (m) => {
+        logs.push(m);
+      },
+    };
+    return {
+      deps,
+      spawns,
+      logs,
+      get reloads() {
+        return reloads;
+      },
+      fire: (p: string) => onChange?.(p),
+      tick: async () => {
+        timerFn?.();
+        await new Promise((r) => setTimeout(r, 0));
+      },
+      settleExit: () => settleLast?.(),
+    };
+  };
+
+  test('a restart waits for the old child to exit before spawning the new one', async () => {
+    const h = makeLifecycle();
+    new DevSupervisor('/proj', 'src/main.ts', h.deps);
+    const first = h.settleExit; // the child spawned in the constructor
+    h.fire('src/main.ts');
+    await h.tick();
+    // Killed, but its exit has not settled — spawning now would leave two live
+    // apps racing for the window and the single-instance lock.
+    expect(h.spawns).toHaveLength(1);
+    first();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(h.spawns).toHaveLength(2);
+  });
+
+  test('a reload after the app quits says so instead of reporting success', async () => {
+    const h = makeLifecycle();
+    new DevSupervisor('/proj', 'src/main.ts', h.deps);
+    h.settleExit(); // the user quit the app
+    await new Promise((r) => setTimeout(r, 0));
+    h.fire('src/index.html');
+    await h.tick();
+    expect(h.reloads).toBe(0);
+    expect(h.logs.join(' ')).toContain('not running');
+  });
+});
+
+describe('makeContentFilter', () => {
+  test('drops a save that did not change the bytes', () => {
+    const changed = makeContentFilter(() => 'same');
+    expect(changed('src/main.ts')).toBe(true);
+    expect(changed('src/main.ts')).toBe(false);
+  });
+
+  test('passes a real edit through', () => {
+    const files = new Map([['src/main.ts', 'v1']]);
+    const changed = makeContentFilter((p) => files.get(p));
+    expect(changed('src/main.ts')).toBe(true);
+    files.set('src/main.ts', 'v2');
+    expect(changed('src/main.ts')).toBe(true);
+  });
+
+  test('tracks each path independently', () => {
+    const changed = makeContentFilter(() => 'same');
+    expect(changed('a.ts')).toBe(true);
+    expect(changed('b.ts')).toBe(true);
+    expect(changed('a.ts')).toBe(false);
+  });
+
+  test('always passes a vanished file through, and re-arms it', () => {
+    const files = new Map([['a.ts', 'v1']]);
+    const changed = makeContentFilter((p) => files.get(p));
+    expect(changed('a.ts')).toBe(true);
+    files.delete('a.ts');
+    expect(changed('a.ts')).toBe(true);
+    files.set('a.ts', 'v1');
+    expect(changed('a.ts')).toBe(true);
   });
 });

--- a/tests/unit/cli/run-command.test.ts
+++ b/tests/unit/cli/run-command.test.ts
@@ -29,6 +29,39 @@ describe('runApp', () => {
     expect(captured).toEqual(['bun', 'run', 'app.ts', '--flag', 'value']);
   });
 
+  test('carries the engine pin into the child environment', async () => {
+    // Without this the app resolves to the system WebKit, which on Windows means
+    // no engine at all.
+    let env: Record<string, string | undefined> | undefined;
+    const spawn = (
+      _cmd: readonly string[],
+      options: { env?: Record<string, string | undefined> },
+    ) => {
+      env = options.env;
+      return { exited: Promise.resolve(0) };
+    };
+
+    await runApp('app.ts', [], {
+      spawn,
+      extraEnv: { BUNMASKA_WEBKIT_ID: 'webkit-2-1.2.3-x-linux-x64' },
+    });
+
+    expect(env?.['BUNMASKA_WEBKIT_ID']).toBe('webkit-2-1.2.3-x-linux-x64');
+    expect(env?.['PATH']).toBeDefined(); // the ambient environment survives
+  });
+
+  test('leaves the environment untouched when there is no pin', async () => {
+    let options: { env?: unknown } | undefined;
+    const spawn = (_cmd: readonly string[], o: { env?: unknown }) => {
+      options = o;
+      return { exited: Promise.resolve(0) };
+    };
+
+    await runApp('app.ts', [], { spawn });
+
+    expect(options?.env).toBeUndefined();
+  });
+
   test('propagates a non-zero child exit code', async () => {
     const spawn = () => ({ exited: Promise.resolve(7) });
     const code = await runApp('app.ts', [], { spawn });

--- a/tests/unit/electron-shim.test.ts
+++ b/tests/unit/electron-shim.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import * as electronShim from '../../src/electron';
 import { createElectronShim } from '../../src/electron';
 import { notImplementedMessage } from '../../src/main/module-list';
 
@@ -24,5 +25,21 @@ describe('createElectronShim', () => {
     const shim = createElectronShim({ clipboard: 'CB' });
     expect(() => shim['clipboard']).not.toThrow();
     expect(shim['clipboard']).toBe('CB');
+  });
+});
+
+describe('bunmaska/electron named exports', () => {
+  test('exposes the modules the migration guide tells people to import', () => {
+    // `import { app, BrowserWindow } from 'bunmaska/electron'` is the documented
+    // drop-in path; it used to throw because only a default export existed.
+    expect(electronShim.app).toBeDefined();
+    expect(typeof electronShim.BrowserWindow).toBe('function');
+    expect(typeof electronShim.ipcMain).toBe('object');
+  });
+
+  test('still ships the Proxy default whose property access is actionable', () => {
+    const surface = electronShim.default as Record<string, unknown>;
+    expect(surface['app']).toBe(electronShim.app);
+    expect(() => surface['netLog']).toThrow(/not yet implemented/);
   });
 });


### PR DESCRIPTION
Stacks on #18. Phase 2a of the dev-loop plan — the cheap, high-payoff half. Does **not** yet add a renderer build step (that is 2b, and it is what finally kills the React-restart problem).

## What was wrong

Seven root causes were traced for the two reported symptoms. This PR closes four of them.

| | fix |
|---|---|
| **RC2** no-op saves restart the app | content-hash filter in the watcher: a metadata-only `touch` or a formatter rewriting identical bytes no longer fires. First sight of a path still passes (no baseline to compare against) — the filter earns its keep from the second save onward. |
| **RC3** `dist` ignored, build output watched | `dist` removed from the ignore list, so a rebuilt renderer bundle finally reaches the window. `build`/`out`/`coverage` and any `*.app` / `*.AppDir` segment ignored instead, because `bunmaska build` defaults its output to the project root. |
| **RC5** preload edits reload a stale script | the preload is read and bundled once in the `BrowserWindow` constructor, so `reload()` re-injects the old source forever. A `preload.*` change now restarts, which is the honest action. Verified end to end: editing the preload used to print `PRELOAD-V1` after the reload; it now prints `PRELOAD-V2`. |
| **RC7** restart races, and reloads at a dead child | `kill()` only delivers a signal, so respawning immediately left two live apps racing for the window and the single-instance lock. The restart now awaits the old child's exit. The supervisor also tracks liveness: after the user quits, a renderer edit says `app is not running` instead of printing `reloaded` at a corpse. |

Also: the watcher classifies before hashing, so `node_modules` churn never costs a file read.

## Engine pin

`bunmaska dev` and `bunmaska run` never read `config.engine.webkit` — only `build` and `doctor` did — so a dev launch silently resolved to the system WebKit, which on Windows means no engine at all. Both now pass `BUNMASKA_WEBKIT_ID` to the child.

## The electron shim

`import { app, BrowserWindow } from "bunmaska/electron"` — the exact line in `migrating-from-electron.md:23`, for the flagship drop-in feature — threw `SyntaxError: Export named 'app' not found`. The module had only a default export. Adding `export * from './index'` fixes the documented path; the default export's Proxy still turns a property access on an unimplemented module into the actionable message, which I checked both ways.

## Tests

Every new behaviour was mutation-checked — I reverted each fix in turn and confirmed a test goes red, rather than assuming coverage:

- drop the `await` on child exit → the restart-race test fails
- drop the liveness guard → the dead-child test fails
- stop restarting on preload → the preload classification test fails
- drop the env wiring → the engine-pin test fails
- remove the named re-exports → the shim test fails

`bun run validate` EXIT=0 (1515 pass / 74 skip / 0 fail).

## Still open, deliberately

RC1 (`.tsx` classified as a main source) and RC4 (no renderer build step anywhere) are 2b. They need bunmaska to own the renderer build, and the binding constraint is that `file://` blocks ES modules while `bun build ./index.html` emits `type="module"` — so the IIFE recipe in `.admin/RENDERER-BUILD.md` is the target, not Bun's HTML entry. RC6 (window state across restart) is blocked on macOS `getBounds()` returning a cached rect that lies once the window moves.